### PR TITLE
feat: embedding generation and SQLite vector DB build

### DIFF
--- a/pipeline/build_db/embed.py
+++ b/pipeline/build_db/embed.py
@@ -1,0 +1,171 @@
+# pipeline/build_db/embed.py
+# Embed all chunks with all-MiniLM-L6-v2 and store in SQLite with sqlite-vec.
+#
+# Usage:
+#   python -m pipeline.build_db.embed
+#
+# Reads:  pipeline/data/processed/chunks.jsonl
+# Writes: pipeline/data/knowledge_base.db
+#
+# Schema:
+#   chunks              — id, chunk_text, source, page_title, chunk_index
+#   chunk_embeddings    — vec0 virtual table; rowid matches chunks.id
+#   chunks_fts          — fts5 virtual table on chunk_text (hybrid search fallback)
+
+import json
+import math
+import sqlite3
+import struct
+import sys
+from pathlib import Path
+
+import sqlite_vec
+from sentence_transformers import SentenceTransformer
+from tqdm import tqdm
+
+from pipeline.config import PROCESSED_DIR, DB_PATH, get_logger
+
+EMBEDDING_DIM = 384
+CHUNKS_PATH = PROCESSED_DIR / "chunks.jsonl"
+
+log = get_logger(__name__)
+
+
+def _load_model() -> SentenceTransformer:
+    log.info("Loading all-MiniLM-L6-v2...")
+    model = SentenceTransformer("all-MiniLM-L6-v2")
+    dim = len(model.encode("probe"))
+    if dim != EMBEDDING_DIM:
+        log.error(
+            "Expected embedding dimension %d, got %d — wrong model loaded. Exiting.",
+            EMBEDDING_DIM,
+            dim,
+        )
+        sys.exit(1)
+    log.info("Model loaded. Embedding dimension: %d", dim)
+    return model
+
+
+def _pack_embedding(vec: list[float]) -> bytes:
+    return struct.pack(f"{len(vec)}f", *vec)
+
+
+def _is_bad_embedding(vec) -> bool:
+    """Return True if the vector is all-zeros or contains any NaN."""
+    return all(v == 0.0 for v in vec) or any(math.isnan(v) for v in vec)
+
+
+def _open_db(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    return conn
+
+
+def _setup_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("DROP TABLE IF EXISTS chunk_embeddings")
+    conn.execute("DROP TABLE IF EXISTS chunks_fts")
+    conn.execute("DROP TABLE IF EXISTS chunks")
+    conn.execute("""
+        CREATE TABLE chunks (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            chunk_text  TEXT    NOT NULL,
+            source      TEXT    NOT NULL,
+            page_title  TEXT    NOT NULL,
+            chunk_index INTEGER NOT NULL
+        )
+    """)
+    conn.execute("""
+        CREATE VIRTUAL TABLE chunk_embeddings USING vec0(
+            embedding float[384]
+        )
+    """)
+    conn.execute("""
+        CREATE VIRTUAL TABLE chunks_fts USING fts5(
+            chunk_text,
+            content='chunks',
+            content_rowid='id'
+        )
+    """)
+    conn.commit()
+
+
+def run(
+    chunks_path: Path = CHUNKS_PATH,
+    db_path: Path = DB_PATH,
+    model: SentenceTransformer | None = None,
+) -> dict:
+    """Embed all chunks and write knowledge_base.db. Returns {inserted, skipped}."""
+    if model is None:
+        model = _load_model()
+
+    raw = chunks_path.read_text(encoding="utf-8").strip().splitlines()
+    chunks = [json.loads(line) for line in raw if line.strip()]
+    log.info("Loaded %d chunks from %s", len(chunks), chunks_path)
+
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = _open_db(db_path)
+    _setup_schema(conn)
+
+    log.info("Encoding %d chunks...", len(chunks))
+    embeddings = model.encode(
+        [c["text"] for c in chunks],
+        batch_size=64,
+        show_progress_bar=True,
+        convert_to_numpy=True,
+    )
+
+    skipped = 0
+    inserted = 0
+
+    for chunk, vec in tqdm(
+        zip(chunks, embeddings),
+        total=len(chunks),
+        desc="Writing DB",
+        unit="chunk",
+    ):
+        if _is_bad_embedding(vec):
+            log.warning(
+                "Skipped bad embedding: chunk_index=%d page_title=%r",
+                chunk["chunk_index"],
+                chunk["page_title"],
+            )
+            skipped += 1
+            continue
+
+        conn.execute(
+            "INSERT INTO chunks (chunk_text, source, page_title, chunk_index) VALUES (?, ?, ?, ?)",
+            (chunk["text"], chunk["source"], chunk["page_title"], chunk["chunk_index"]),
+        )
+        row_id = conn.execute("SELECT last_insert_rowid()").fetchone()[0]
+        conn.execute(
+            "INSERT INTO chunk_embeddings(rowid, embedding) VALUES (?, ?)",
+            (row_id, _pack_embedding(vec.tolist())),
+        )
+        conn.execute(
+            "INSERT INTO chunks_fts(rowid, chunk_text) VALUES (?, ?)",
+            (row_id, chunk["text"]),
+        )
+        inserted += 1
+
+    conn.commit()
+    conn.close()
+
+    total = inserted + skipped
+    log.info("Embedding complete — inserted: %d, skipped: %d", inserted, skipped)
+
+    if total > 0 and skipped / total > 0.01:
+        log.error(
+            "Skipped %d / %d chunks (%.1f%%) exceeds 1%% threshold — CI failure.",
+            skipped,
+            total,
+            100.0 * skipped / total,
+        )
+        sys.exit(1)
+
+    return {"inserted": inserted, "skipped": skipped}
+
+
+if __name__ == "__main__":
+    run()

--- a/pipeline/tests/test_build_db.py
+++ b/pipeline/tests/test_build_db.py
@@ -1,0 +1,303 @@
+# pipeline/tests/test_build_db.py
+# Tests for embedding generation and SQLite vector DB build.
+# SentenceTransformer is mocked — no live model downloads in tests.
+
+import json
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import sqlite_vec
+
+from pipeline.build_db.embed import (
+    EMBEDDING_DIM,
+    _is_bad_embedding,
+    _open_db,
+    _pack_embedding,
+    run,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_model(bad_indices: set[int] | None = None) -> MagicMock:
+    """Return a mock SentenceTransformer.
+
+    Vectors at positions in bad_indices are zero-vectors; all others are valid.
+    """
+    bad_indices = bad_indices or set()
+    model = MagicMock()
+
+    def encode(texts, **kwargs):
+        vecs = []
+        for i, _ in enumerate(texts):
+            vec = np.full(EMBEDDING_DIM, 0.1 * (i + 1), dtype=np.float32)
+            if i in bad_indices:
+                vec[:] = 0.0
+            vecs.append(vec)
+        return np.array(vecs, dtype=np.float32)
+
+    model.encode.side_effect = encode
+    return model
+
+
+@pytest.fixture
+def mock_model():
+    return _make_model()
+
+
+def _write_chunks(path: Path, count: int) -> Path:
+    records = [
+        {
+            "source": "zelda_wiki",
+            "page_title": f"Page {i}",
+            "chunk_index": 0,
+            "text": f"This is chunk text number {i}. " * 10,
+        }
+        for i in range(count)
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+    return path
+
+
+@pytest.fixture
+def sample_chunks_file(tmp_path: Path) -> Path:
+    """10-chunk file — enough for happy-path tests."""
+    return _write_chunks(tmp_path / "chunks.jsonl", 10)
+
+
+@pytest.fixture
+def large_chunks_file(tmp_path: Path) -> Path:
+    """200-chunk file — 1 bad chunk stays well under 1% threshold."""
+    return _write_chunks(tmp_path / "chunks_large.jsonl", 200)
+
+
+# ---------------------------------------------------------------------------
+# _is_bad_embedding
+# ---------------------------------------------------------------------------
+
+
+def test_is_bad_embedding_zero_vector():
+    assert _is_bad_embedding([0.0] * EMBEDDING_DIM) is True
+
+
+def test_is_bad_embedding_nan_in_vector():
+    vec = [0.5] * EMBEDDING_DIM
+    vec[10] = float("nan")
+    assert _is_bad_embedding(vec) is True
+
+
+def test_is_bad_embedding_valid_vector():
+    assert _is_bad_embedding([0.1] * EMBEDDING_DIM) is False
+
+
+def test_is_bad_embedding_single_nonzero_is_valid():
+    vec = [0.0] * EMBEDDING_DIM
+    vec[0] = 0.001
+    assert _is_bad_embedding(vec) is False
+
+
+# ---------------------------------------------------------------------------
+# _pack_embedding
+# ---------------------------------------------------------------------------
+
+
+def test_pack_embedding_byte_length():
+    packed = _pack_embedding([0.5] * EMBEDDING_DIM)
+    assert len(packed) == EMBEDDING_DIM * 4  # 4 bytes per float32
+
+
+def test_pack_embedding_roundtrips():
+    import struct
+
+    original = [float(i) / EMBEDDING_DIM for i in range(EMBEDDING_DIM)]
+    packed = _pack_embedding(original)
+    unpacked = list(struct.unpack(f"{EMBEDDING_DIM}f", packed))
+    assert unpacked == pytest.approx(original, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# run() — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_run_creates_db_file(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    assert db_path.exists()
+
+
+def test_run_returns_stats(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    stats = run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    assert stats["inserted"] == 10
+    assert stats["skipped"] == 0
+
+
+def test_chunks_table_row_count(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    conn = sqlite3.connect(db_path)
+    count = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    conn.close()
+    assert count == 10
+
+
+def test_chunks_table_columns(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT id, chunk_text, source, page_title, chunk_index FROM chunks LIMIT 1"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert len(row) == 5
+
+
+def test_chunks_metadata_stored_correctly(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT source, page_title, chunk_index FROM chunks WHERE id = 1"
+    ).fetchone()
+    conn.close()
+    assert row == ("zelda_wiki", "Page 0", 0)
+
+
+# ---------------------------------------------------------------------------
+# run() — embeddings table
+# ---------------------------------------------------------------------------
+
+
+def test_embeddings_table_exists(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    conn = sqlite3.connect(db_path)
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    result = conn.execute(
+        "SELECT name FROM sqlite_master WHERE name = 'chunk_embeddings'"
+    ).fetchone()
+    conn.close()
+    assert result is not None
+
+
+def test_embeddings_row_count_matches_chunks(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    conn = sqlite3.connect(db_path)
+    conn.enable_load_extension(True)
+    sqlite_vec.load(conn)
+    conn.enable_load_extension(False)
+    count = conn.execute("SELECT COUNT(*) FROM chunk_embeddings").fetchone()[0]
+    conn.close()
+    assert count == 10
+
+
+# ---------------------------------------------------------------------------
+# run() — FTS5 table
+# ---------------------------------------------------------------------------
+
+
+def test_fts_table_exists(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    conn = sqlite3.connect(db_path)
+    result = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'chunks_fts'"
+    ).fetchone()
+    conn.close()
+    assert result is not None
+
+
+def test_fts_search_returns_results(tmp_path, mock_model, sample_chunks_file):
+    db_path = tmp_path / "kb.db"
+    run(chunks_path=sample_chunks_file, db_path=db_path, model=mock_model)
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT rowid FROM chunks_fts WHERE chunk_text MATCH 'chunk' LIMIT 5"
+    ).fetchall()
+    conn.close()
+    assert len(rows) > 0
+
+
+# ---------------------------------------------------------------------------
+# run() — bad embedding filtering
+# ---------------------------------------------------------------------------
+
+
+def test_skips_zero_vector(tmp_path, large_chunks_file):
+    db_path = tmp_path / "kb.db"
+    model = _make_model(bad_indices={0})
+    stats = run(chunks_path=large_chunks_file, db_path=db_path, model=model)
+    assert stats["skipped"] == 1
+    assert stats["inserted"] == 199
+
+
+def test_skips_nan_vector(tmp_path, large_chunks_file):
+    db_path = tmp_path / "kb.db"
+    model = MagicMock()
+
+    def encode(texts, **kwargs):
+        vecs = []
+        for i, _ in enumerate(texts):
+            vec = np.full(EMBEDDING_DIM, 0.5, dtype=np.float32)
+            if i == 3:
+                vec[5] = float("nan")
+            vecs.append(vec)
+        return np.array(vecs, dtype=np.float32)
+
+    model.encode.side_effect = encode
+    stats = run(chunks_path=large_chunks_file, db_path=db_path, model=model)
+    assert stats["skipped"] == 1
+    assert stats["inserted"] == 199
+
+
+def test_skipped_chunk_not_in_db(tmp_path, large_chunks_file):
+    db_path = tmp_path / "kb.db"
+    model = _make_model(bad_indices={0})  # "Page 0" is skipped
+    run(chunks_path=large_chunks_file, db_path=db_path, model=model)
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT id FROM chunks WHERE page_title = 'Page 0'"
+    ).fetchone()
+    conn.close()
+    assert row is None
+
+
+# ---------------------------------------------------------------------------
+# run() — 1% skip threshold
+# ---------------------------------------------------------------------------
+
+
+def test_exits_when_skip_rate_exceeds_threshold(tmp_path, sample_chunks_file):
+    """2 bad out of 10 = 20% > 1% — should sys.exit(1)."""
+    db_path = tmp_path / "kb.db"
+    model = _make_model(bad_indices={0, 1})
+    with pytest.raises(SystemExit) as exc_info:
+        run(chunks_path=sample_chunks_file, db_path=db_path, model=model)
+    assert exc_info.value.code == 1
+
+
+def test_no_exit_when_skip_rate_at_threshold(tmp_path):
+    """Exactly 1 bad out of 101 ≈ 0.99% < 1% — should not exit."""
+    chunks_path = tmp_path / "chunks.jsonl"
+    records = [
+        {"source": "zelda_wiki", "page_title": f"P{i}", "chunk_index": 0, "text": f"text {i} " * 10}
+        for i in range(101)
+    ]
+    chunks_path.write_text("\n".join(json.dumps(r) for r in records), encoding="utf-8")
+
+    model = _make_model(bad_indices={0})  # 1/101 ≈ 0.99%
+    db_path = tmp_path / "kb.db"
+    stats = run(chunks_path=chunks_path, db_path=db_path, model=model)
+    assert stats["skipped"] == 1
+    assert stats["inserted"] == 100


### PR DESCRIPTION
Closes #6

## Summary
- `pipeline/build_db/embed.py` — loads all-MiniLM-L6-v2, asserts 384-dim on startup, encodes all chunks from `chunks.jsonl` with tqdm progress, writes `knowledge_base.db` with three tables: `chunks`, `chunk_embeddings` (vec0 virtual table), `chunks_fts` (FTS5 hybrid search fallback)
- Skips and logs any zero-vector or NaN-containing embedding; exits non-zero if skip rate exceeds 1%
- `pipeline/tests/test_build_db.py` — 20 tests covering schema, row counts, FTS search, bad-embedding filtering, and the 1% threshold; SentenceTransformer is mocked (no live model downloads)

## Test plan
- [x] `pytest pipeline/tests/test_build_db.py` — 20 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)