### PR TITLE
fix: add pytest and numpy<2.0 to model/requirements.txt

### DIFF
--- a/model/requirements.txt
+++ b/model/requirements.txt
@@ -2,3 +2,5 @@ coremltools==8.0
 transformers==4.45.0
 torch==2.4.0
 sentence-transformers==3.0.1
+numpy<2.0
+pytest


### PR DESCRIPTION
## Summary
- `pytest` was missing from `model/requirements.txt` — CI exited 127 ("command not found") on the unit tests step
- `coremltools==8.0` is incompatible with numpy 2.x — pins `numpy<2.0` to fix a `TypeError` during Core ML conversion (`only 0-dimensional arrays can be converted to Python scalars`)

Both failures were visible in the first Convert Core ML model workflow run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)