### PR TITLE
docs: switch distribution to SideStore and LLM to Qwen2.5

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ which are fed to an on-device LLM to generate a contextual answer. No hallucinat
 
 ## Intended user
 Personal use - single user, no accounts, no backend, no cloud. The app and its data live entirely on the device.
-Distributed via AltStore sideloading - no Apple Developer account required.
+Distributed via SideStore sideloading - no Apple Developer account required.
 
 ---
 
@@ -20,14 +20,14 @@ The LLM is fully configurable via a single file (ModelConfig.swift). Default is 
 
 | Setting | 1B (default) | 3B (upgrade path) |
 |---------|-------------|-------------------|
-| Model | Llama 3.2 1B Instruct | Llama 3.2 3B Instruct |
-| Quantized size | ~600MB | ~1.8GB |
-| App total size | ~750MB | ~2.5GB |
+| Model | Qwen2.5 1.5B Instruct | Qwen2.5 3B Instruct |
+| Quantized size | ~750MB | ~1.5GB |
+| App total size | ~900MB | ~1.8GB |
 | Min device | Any iPhone (iOS 17) | Any iPhone (iOS 17) |
 | Speed on A15 | ~15 tok/sec | ~8 tok/sec |
 | Speed on A17 Pro | ~25 tok/sec | ~20 tok/sec |
 | Answer quality | Good for factual Q&A | Better for complex questions |
-| Distribution | AltStore free Apple ID | Paid Apple Developer account needed |
+| Distribution | SideStore free Apple ID | SideStore free Apple ID |
 
 Switching from 1B to 3B requires only:
 1. Change one constant in ModelConfig.swift
@@ -60,10 +60,10 @@ No other code changes needed anywhere.
 - knowledge_base.db bundled in the app at build time
 
 ### Distribution
-- AltStore sideloading via free Apple ID
+- SideStore sideloading via free Apple ID
 - GitHub Actions builds an unsigned .ipa artifact
-- AltStore downloads and signs it with your free Apple ID
-- AltStore Daemon auto-renews the signature every 7 days over Wi-Fi
+- SideStore signs it with your free Apple ID
+- SideStore auto-renews the signature every 7 days over the internet (no home Wi-Fi needed)
 
 ---
 
@@ -105,7 +105,7 @@ Zelda-RAGs-of-the-Kingdom/
     requirements.txt
   model/
     convert_embeddings.py     # all-MiniLM-L6-v2 -> Core ML
-    convert_llm.py            # Llama 1B or 3B -> Core ML (MODEL_VARIANT)
+    convert_llm.py            # Qwen2.5 1.5B or 3B -> Core ML (MODEL_VARIANT)
     requirements.txt
   ios/
     ZeldaGuide/
@@ -151,9 +151,9 @@ Do not change these without an ADR in docs/decisions/.
 
 - The iOS app makes zero network requests at runtime. All inference is local.
 
-- AltStore distribution uses an unsigned .ipa. AltStore signs it with the user's free Apple ID.
+- SideStore distribution uses an unsigned .ipa. SideStore signs it with the user's free Apple ID.
   The 3-app limit and 7-day expiry are the only real constraints of a free Apple ID.
-  AltStore Daemon handles auto-renewal when the phone is on the same Wi-Fi as the PC.
+  SideStore auto-renews over the internet via its built-in WireGuard VPN — no PC or home Wi-Fi needed.
 
 ---
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -1,31 +1,28 @@
-# Building and installing with AltStore
+# Building and installing with SideStore
 
 ## Prerequisites
-- AltStore installed on your iPhone and PC (https://altstore.io)
-- AltStore Daemon running on your PC
+- SideStore installed on your iPhone (https://sidestore.io)
+- A free Apple ID
 - GitHub account with this repo
 
-## Building the .ipa
+SideStore re-signs apps over the internet via a built-in WireGuard VPN — no PC or home Wi-Fi required.
+This means the app stays valid while travelling.
 
+## Building the .ipa
 1. Go to the GitHub Actions tab in this repo
 2. Select the 'Build iOS .ipa' workflow
 3. Click 'Run workflow'
 4. Wait ~15 minutes for the build to complete
 5. Download the .ipa artifact from the completed run
 
-## Installing with AltStore
-
-1. Connect your iPhone to your PC via USB (first time only)
-2. Open AltStore on your iPhone
-3. Tap the + button and select the downloaded .ipa file
-4. The app will install and sign with your free Apple ID
+## Installing with SideStore
+1. Open SideStore on your iPhone
+2. Tap the + button and select the downloaded .ipa file
+3. The app will install and sign with your free Apple ID
 
 ## Auto-renewal
-
-AltStore Daemon on your PC will automatically re-sign the app every 7 days
-when your iPhone is on the same Wi-Fi network as your PC.
-You do not need to manually reinstall unless you delete the app.
+SideStore automatically re-signs the app every 7 days using its built-in WireGuard VPN.
+No PC or home Wi-Fi needed — renewal works anywhere you have an internet connection.
 
 ## Switching to the 3B model
-
-See docs/upgrade-to-3b.md when you have a paid Apple Developer account.
+See docs/upgrade-to-3b.md for steps to switch to the 3B model.

--- a/docs/upgrade-to-3b.md
+++ b/docs/upgrade-to-3b.md
@@ -1,6 +1,6 @@
 # Upgrading from 1B to 3B model
 
-When you have a paid Apple Developer account and want better answer quality:
+When you want better answer quality for complex questions:
 
 ## Steps
 
@@ -25,4 +25,4 @@ When you have a paid Apple Developer account and want better answer quality:
 
 - The 3B model requires ~1.8GB of storage vs ~600MB for 1B
 - All other code stays the same - ModelConfig.swift handles all differences
-- You will need to set up Apple Developer signing in build-ipa.yml (see comments in that file)
+- Sideload with SideStore the same way as the 1B build

--- a/model/convert_llm.py
+++ b/model/convert_llm.py
@@ -1,16 +1,16 @@
 """
 convert_llm.py
-Converts Llama 3.2 1B or 3B Instruct from HuggingFace to a Core ML .mlpackage
+Converts Qwen2.5 1.5B or 3B Instruct from HuggingFace to a Core ML .mlpackage
 with 4-bit palettization quantization, for on-device inference on iOS.
 
 Output: model/LlamaModel-1B.mlpackage  or  model/LlamaModel-3B.mlpackage
   - Stateful model with KV-cache state (requires iOS 18+)
   - 4-bit palettized weights via coremltools.optimize.coreml
-  - 1B output must be under 700 MB; 3B under 2 GB
+  - 1B output must be under 800 MB; 3B under 2 GB
 
 Environment variables:
   MODEL_VARIANT  "1B" (default) or "3B"
-  HF_TOKEN       HuggingFace token — must have accepted Meta's Llama 3.2 licence
+  HF_TOKEN       HuggingFace token (Qwen2.5 models are ungated — token still needed for rate limits)
 
 Usage:
     python model/convert_llm.py [--output-dir <dir>]
@@ -36,13 +36,13 @@ from pathlib import Path
 _MODELCONFIG_PATH = Path(__file__).parent.parent / "ios" / "ZeldaGuide" / "Services" / "ModelConfig.swift"
 
 _HF_IDS = {
-    "1B": "meta-llama/Llama-3.2-1B-Instruct",
-    "3B": "meta-llama/Llama-3.2-3B-Instruct",
+    "1B": "Qwen/Qwen2.5-1.5B-Instruct",
+    "3B": "Qwen/Qwen2.5-3B-Instruct",
 }
 
 # Maximum on-disk size for the .mlpackage bundle (bytes)
 _SIZE_LIMITS = {
-    "1B": 700 * 1024 * 1024,   # 700 MB
+    "1B": 800 * 1024 * 1024,   # 800 MB  (Qwen2.5-1.5B at 4-bit ~750 MB)
     "3B": 2 * 1024 * 1024 * 1024,  # 2 GB
 }
 


### PR DESCRIPTION
## Summary
- Replace AltStore with SideStore — re-signs over the internet so the app stays valid while travelling, no home Wi-Fi needed
- Swap LLM from Llama 3.2 (gated, approval pending) to Qwen2.5-1.5B/3B-Instruct (ungated, no approval needed)
- Bump 1B size limit to 800 MB to accommodate Qwen2.5-1.5B at 4-bit (~750 MB)

## Test plan
- [ ] Re-run Convert Core ML model workflow — should now download Qwen2.5-1.5B without a 403
- [ ] Verify docs/build.md reflects SideStore install steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)