### PR TITLE
fix: update 1B size limit in test to match 800MB threshold

### DIFF
--- a/model/tests/test_convert_llm.py
+++ b/model/tests/test_convert_llm.py
@@ -140,7 +140,7 @@ def test_assert_size_passes_small_file(tmp_path):
 def test_assert_size_exits_1b_over_limit(tmp_path):
     pkg = tmp_path / "LlamaModel-1B.mlpackage"
     pkg.mkdir()
-    limit_1b = 700 * 1024 * 1024
+    limit_1b = 800 * 1024 * 1024
     # Patch stat to report oversized file without writing gigabytes
     fake_file = MagicMock()
     fake_stat = MagicMock()


### PR DESCRIPTION
Test was still using the old 700 MB limit after we bumped it to 800 MB for Qwen2.5-1.5B. Closes the unit test failure in the Convert LLM CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)