### PR TITLE
fix: use strict=False in torch.export for autocast compatibility

### DIFF
--- a/model/convert_llm.py
+++ b/model/convert_llm.py
@@ -195,6 +195,7 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
             model,
             example_inputs,
             dynamic_shapes=dynamic_shapes,
+            strict=False,  # required for models that use autocast internally
         )
 
     # --- Core ML stateful conversion ---


### PR DESCRIPTION
Qwen2.5 uses autocast internally, which causes `torch.export` strict mode to fail with `SpecViolationError: Node.meta _enter_autocast is missing val field`. Setting `strict=False` uses the non-strict export path which handles autocast correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)