### PR TITLE
fix: load model in float16 for both variants to avoid OOM

### DIFF
--- a/model/convert_llm.py
+++ b/model/convert_llm.py
@@ -156,8 +156,8 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
     print(f"Filename sync OK: {derived}")
 
     hf_id = _HF_IDS[variant]
-    # 3B is too large in float32 on the 14 GB CI runner — use float16
-    torch_dtype = torch.float16 if variant == "3B" else torch.float32
+    # Use float16 for both variants — float32 OOMs the 14 GB CI runner
+    torch_dtype = torch.float16
 
     print(f"Loading {hf_id} …")
     tokenizer = AutoTokenizer.from_pretrained(hf_id, token=hf_token)


### PR DESCRIPTION
Loading Qwen2.5-1.5B in float32 plus tracing/conversion overhead exceeds the 14 GB macos-14 runner RAM limit (exit code 137). Use float16 for both variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)