### PR TITLE
fix: switch to torch-level palettization to avoid post-conversion OOM

### DIFF
--- a/model/convert_llm.py
+++ b/model/convert_llm.py
@@ -139,10 +139,9 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
     import numpy as np
     import torch
     import coremltools as ct
-    from coremltools.optimize.coreml import (
-        OptimizationConfig,
-        OpPalettizerConfig,
-        palettize_weights,
+    from coremltools.optimize.torch.palettization import (
+        PostTrainingPalettizer,
+        PostTrainingPalettizerConfig,
     )
     import gc
     from transformers import AutoTokenizer, AutoModelForCausalLM
@@ -191,24 +190,41 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
         f"{num_kv_heads} KV heads, head_dim={head_dim}, max_seq={max_seq}"
     )
 
-    # --- Trace with torch.jit.trace ---
-    # Stateless approach: the full sequence is passed each step (no KV cache).
-    # Simpler and more compatible than torch.export + StateType, and sufficient
-    # for a short-answer Q&A app where outputs are typically < 200 tokens.
+    # --- 4-bit torch-level palettization (pre-conversion) ---
+    # Palettize the PyTorch model weights BEFORE CoreML conversion so we never
+    # hold a large uncompressed CoreML model in memory (which OOMs the runner).
+    print("Applying 4-bit torch-level palettization …")
+    pal_config = PostTrainingPalettizerConfig.from_dict({
+        "global_config": {
+            "n_bits": 4,
+            "granularity": "per_grouped_channel",
+            "group_size": 16,
+        }
+    })
+    palettizer = PostTrainingPalettizer(wrapped, pal_config)
+    compressed_wrapped = palettizer.compress()
+    del model, wrapped
+    gc.collect()
+
+    # --- Trace the already-compressed model ---
     # Use seq_len=8 so the tracer doesn't constant-fold the sequence dimension.
-    print("Tracing with torch.jit.trace …")
+    print("Tracing compressed model with torch.jit.trace …")
     example_inputs = (
         torch.zeros(1, 8, dtype=torch.int64),
         torch.ones(1, 8, dtype=torch.int64),
     )
     with torch.no_grad():
-        traced = torch.jit.trace(wrapped, example_inputs)
+        traced = torch.jit.trace(compressed_wrapped, example_inputs)
+    del compressed_wrapped
+    gc.collect()
 
     # --- Core ML conversion ---
     # Cap dynamic sequence at 512 tokens (prompt + context + answer).
+    # coremltools recognises the torch-level palettization and produces a
+    # compressed mlpackage directly — no post-conversion quantization needed.
     max_context = 512
     print("Converting to Core ML …")
-    mlmodel = ct.convert(
+    compressed = ct.convert(
         traced,
         inputs=[
             ct.TensorType(name="input_ids", shape=(1, ct.RangeDim(1, max_context)), dtype=np.int32),
@@ -218,23 +234,7 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
         minimum_deployment_target=ct.target.iOS17,
         compute_units=ct.ComputeUnit.CPU_AND_NE,
     )
-
-    # --- 4-bit palettization (uniform mode) ---
-    # Use uniform mode (pre-computed bins) instead of kmeans — kmeans clusters
-    # all weight tensors in memory which OOMs the 14 GB CI runner.
-    print("Applying 4-bit palettization (uniform) …")
-    # Free torch model before quantizing to reduce peak memory
-    del model, wrapped, traced
-    gc.collect()
-    config = OptimizationConfig(
-        global_config=OpPalettizerConfig(
-            mode="uniform",
-            nbits=4,
-            weight_threshold=512,
-        )
-    )
-    compressed = palettize_weights(mlmodel, config)
-    del mlmodel
+    del traced
     gc.collect()
 
     # --- Smoke test: generate _SMOKE_TEST_MIN_TOKENS tokens ---

--- a/model/tests/test_convert_llm.py
+++ b/model/tests/test_convert_llm.py
@@ -242,17 +242,21 @@ def _make_optimize_mock():
     logits = np.zeros((1, 1, vocab_size), dtype=np.float32)
     logits[0, 0, 42] = 1.0
 
+    # compressed_mock is returned by ct.convert() (torch-level palettization
+    # means ct.convert() produces the final compressed model directly)
     compressed_mock = MagicMock()
-    compressed_mock.make_state.return_value = MagicMock()
     compressed_mock.predict.return_value = {"logits": logits}
     compressed_mock.save = MagicMock()
 
-    optimize_mock = MagicMock()
-    optimize_mock.palettize_weights.return_value = compressed_mock
-    optimize_mock.OptimizationConfig = MagicMock
-    optimize_mock.OpPalettizerConfig = MagicMock
+    # torch_optimize_mock represents coremltools.optimize.torch.palettization
+    torch_optimize_mock = MagicMock()
+    palettizer_mock = MagicMock()
+    palettizer_mock.compress.return_value = MagicMock()
+    torch_optimize_mock.PostTrainingPalettizer.return_value = palettizer_mock
+    torch_optimize_mock.PostTrainingPalettizerConfig = MagicMock()
+    torch_optimize_mock.PostTrainingPalettizerConfig.from_dict.return_value = MagicMock()
 
-    return optimize_mock, compressed_mock
+    return torch_optimize_mock, compressed_mock
 
 
 @pytest.fixture
@@ -278,12 +282,16 @@ def _patch_heavy(tmp_path, monkeypatch):
     transformers_mock.AutoTokenizer.from_pretrained.return_value = tokenizer_mock
     transformers_mock.AutoModelForCausalLM.from_pretrained.return_value = model_mock
 
+    # ct.convert returns the compressed_mock directly (torch-level palettization)
+    ct_mock.convert.return_value = compressed_mock
+
     with patch.dict(sys.modules, {
         "torch": torch_mock,
         "torch.export": torch_mock.export,
         "coremltools": ct_mock,
         "coremltools.optimize": MagicMock(),
-        "coremltools.optimize.coreml": optimize_mock,
+        "coremltools.optimize.torch": MagicMock(),
+        "coremltools.optimize.torch.palettization": optimize_mock,
         "transformers": transformers_mock,
     }):
         monkeypatch.setenv("MODEL_VARIANT", "1B")
@@ -300,11 +308,11 @@ def test_convert_calls_ct_convert(_patch_heavy):
     ct_mock.convert.assert_called_once()
 
 
-def test_convert_calls_palettize(_patch_heavy):
+def test_convert_calls_palettizer(_patch_heavy):
     tmp_path, _, optimize_mock, _ = _patch_heavy
     from model.convert_llm import convert
     convert(str(tmp_path), "1B", "fake-token")
-    optimize_mock.palettize_weights.assert_called_once()
+    optimize_mock.PostTrainingPalettizer.assert_called_once()
 
 
 def test_convert_saves_correct_filename(_patch_heavy):


### PR DESCRIPTION
Post-conversion `palettize_weights` holds both the uncompressed (~3 GB) and compressed CoreML model in memory simultaneously, which OOMs the 14 GB macos-14 runner. Switch to `PostTrainingPalettizer` (torch-level), which compresses weights before CoreML conversion — the converted model is already small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)