### PR TITLE
fix: save mlpackage before smoke test; add skip_conversion workflow input

### DIFF
--- a/.github/workflows/convert-model.yml
+++ b/.github/workflows/convert-model.yml
@@ -1,11 +1,14 @@
 # .github/workflows/convert-model.yml
-# Converts embedding model and Llama LLM to Core ML on a macOS runner.
+# Converts embedding model and Qwen2.5 LLM to Core ML on a macOS runner.
 #
 # Jobs:
 #   convert-embeddings  — all-MiniLM-L6-v2 → MiniLMEmbedder.mlpackage   (issue #8)
-#   convert-llm         — Llama 3.2 1B/3B  → LlamaModel.mlpackage        (issue #9, placeholder)
+#   convert-llm         — Qwen2.5 1B/3B     → LlamaModel.mlpackage        (issue #9)
 #
-# MODEL_VARIANT input controls which Llama variant to convert: "1B" (default) or "3B"
+# Inputs:
+#   model_variant      — "1B" (default) or "3B"
+#   skip_conversion    — if true, downloads the existing artifact and only runs smoke test.
+#                        Use this after a failed smoke test to avoid re-running the 1h+ conversion.
 name: Convert Core ML model
 on:
   workflow_dispatch:
@@ -16,6 +19,11 @@ on:
         default: '1B'
         type: choice
         options: ['1B', '3B']
+      skip_conversion:
+        description: 'Skip conversion — reuse existing artifact (smoke test only)'
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   convert-embeddings:
@@ -59,8 +67,8 @@ jobs:
           echo "- Runner: macos-14" >> $GITHUB_STEP_SUMMARY
 
   convert-llm:
-    name: Convert LLM (Llama ${{ github.event.inputs.model_variant }})
-    runs-on: macos-14
+    name: Convert LLM (Qwen2.5-${{ github.event.inputs.model_variant }})
+    runs-on: macos-15
     env:
       MODEL_VARIANT: ${{ github.event.inputs.model_variant }}
     steps:
@@ -79,24 +87,43 @@ jobs:
       - name: Run unit tests
         run: pytest model/tests/test_convert_llm.py -v
 
-      - name: Convert Llama to Core ML
+      # --- Full conversion path (skip_conversion = false) ---
+
+      - name: Convert Qwen2.5 to Core ML
+        if: ${{ github.event.inputs.skip_conversion != 'true' }}
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: python model/convert_llm.py --output-dir model/
 
       - name: Upload LlamaModel artifact
+        if: ${{ github.event.inputs.skip_conversion != 'true' && always() }}
         uses: actions/upload-artifact@v4
         with:
           name: LlamaModel-${{ github.event.inputs.model_variant }}.mlpackage
           path: model/LlamaModel-${{ github.event.inputs.model_variant }}.mlpackage
           retention-days: 30
 
+      # --- Smoke-test-only path (skip_conversion = true) ---
+
+      - name: Download existing artifact
+        if: ${{ github.event.inputs.skip_conversion == 'true' }}
+        uses: actions/download-artifact@v4
+        with:
+          name: LlamaModel-${{ github.event.inputs.model_variant }}.mlpackage
+          path: model/LlamaModel-${{ github.event.inputs.model_variant }}.mlpackage
+
+      - name: Smoke test existing artifact
+        if: ${{ github.event.inputs.skip_conversion == 'true' }}
+        run: python model/smoke_test_llm.py --model-path "model/LlamaModel-${MODEL_VARIANT}.mlpackage"
+
       - name: Write job summary
         if: always()
         run: |
           ARTIFACT="model/LlamaModel-${MODEL_VARIANT}.mlpackage"
           SIZE=$(du -sh "$ARTIFACT" 2>/dev/null | cut -f1 || echo "n/a")
+          SKIPPED="${{ github.event.inputs.skip_conversion }}"
           echo "## LLM Conversion Summary" >> $GITHUB_STEP_SUMMARY
           echo "- Model variant: $MODEL_VARIANT" >> $GITHUB_STEP_SUMMARY
           echo "- Output: LlamaModel-${MODEL_VARIANT}.mlpackage ($SIZE)" >> $GITHUB_STEP_SUMMARY
-          echo "- Runner: macos-14" >> $GITHUB_STEP_SUMMARY
+          echo "- Conversion skipped: $SKIPPED" >> $GITHUB_STEP_SUMMARY
+          echo "- Runner: macos-15" >> $GITHUB_STEP_SUMMARY

--- a/model/convert_llm.py
+++ b/model/convert_llm.py
@@ -237,6 +237,14 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
     del traced
     gc.collect()
 
+    # --- Save (before smoke test so the artifact is always available) ---
+    save_path = out_path / derived
+    print(f"Saving to {save_path} …")
+    compressed.save(str(save_path))
+
+    # --- Size check ---
+    _assert_size(save_path, variant)
+
     # --- Smoke test: generate _SMOKE_TEST_MIN_TOKENS tokens ---
     print(f"Running smoke test ({_SMOKE_TEST_MIN_TOKENS} tokens) …")
     enc = tokenizer("What is the Hylian Shield?", return_tensors="pt")
@@ -256,15 +264,6 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
     decoded = tokenizer.decode(generated_tokens, skip_special_tokens=True)
     print(f"Smoke test output: {decoded!r}")
     _assert_smoke_test(generated_tokens)
-    print("Smoke test passed.")
-
-    # --- Save ---
-    save_path = out_path / derived
-    print(f"Saving to {save_path} …")
-    compressed.save(str(save_path))
-
-    # --- Size check ---
-    _assert_size(save_path, variant)
     print(f"Done: {save_path}")
 
 

--- a/model/smoke_test_llm.py
+++ b/model/smoke_test_llm.py
@@ -1,0 +1,79 @@
+"""
+smoke_test_llm.py
+Loads an existing LlamaModel .mlpackage and runs the same 20-token smoke test
+used by convert_llm.py. Use this to re-validate a converted model without
+re-running the full 1h+ conversion.
+
+Usage:
+    python model/smoke_test_llm.py --model-path model/LlamaModel-1B.mlpackage
+
+Environment variables:
+    MODEL_VARIANT   "1B" (default) or "3B" — selects the tokenizer to load
+    HF_TOKEN        HuggingFace token (optional for Qwen2.5 ungated models)
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import coremltools as ct
+from transformers import AutoTokenizer
+
+from model.convert_llm import (
+    _HF_IDS,
+    _SMOKE_TEST_MIN_TOKENS,
+    _assert_smoke_test,
+    _assert_size,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Smoke test an existing LlamaModel .mlpackage")
+    parser.add_argument("--model-path", required=True, help="Path to the .mlpackage directory")
+    args = parser.parse_args()
+
+    variant = os.environ.get("MODEL_VARIANT", "1B")
+    hf_token = os.environ.get("HF_TOKEN", "")
+
+    model_path = Path(args.model_path)
+    if not model_path.exists():
+        print(f"ERROR: {model_path} does not exist.", file=sys.stderr)
+        sys.exit(1)
+
+    hf_id = _HF_IDS.get(variant)
+    if hf_id is None:
+        print(f"ERROR: Unknown MODEL_VARIANT '{variant}'.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Loading tokenizer from {hf_id} …")
+    tokenizer = AutoTokenizer.from_pretrained(hf_id, token=hf_token or None)
+
+    print(f"Loading Core ML model from {model_path} …")
+    model = ct.models.MLModel(str(model_path))
+
+    # Size check
+    _assert_size(model_path, variant)
+
+    print(f"Running smoke test ({_SMOKE_TEST_MIN_TOKENS} tokens) …")
+    enc = tokenizer("What is the Hylian Shield?", return_tensors="pt")
+    input_ids = enc["input_ids"].numpy().astype(np.int32)
+    attention_mask = enc["attention_mask"].numpy().astype(np.int32)
+
+    generated_tokens = []
+    for _ in range(_SMOKE_TEST_MIN_TOKENS):
+        output = model.predict({"input_ids": input_ids, "attention_mask": attention_mask})
+        next_token = int(np.argmax(output["logits"][0, -1, :]))
+        generated_tokens.append(next_token)
+        input_ids = np.append(input_ids, [[next_token]], axis=1).astype(np.int32)
+        attention_mask = np.ones((1, input_ids.shape[1]), dtype=np.int32)
+
+    decoded = tokenizer.decode(generated_tokens, skip_special_tokens=True)
+    print(f"Smoke test output: {decoded!r}")
+    _assert_smoke_test(generated_tokens)
+    print("Smoke test passed.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Reorders `convert_llm.py` to **save and size-check the `.mlpackage` before running the smoke test**, so the artifact is always uploaded even if the smoke test fails — avoids re-running the 1h+ conversion just to retry a smoke test
- Upload step now uses `always()` so it runs even when the smoke test step fails
- Adds `skip_conversion` boolean input to `convert-model.yml`: when checked, downloads the existing artifact and runs only the smoke test via the new `model/smoke_test_llm.py` script

## Test plan
- [ ] Current in-progress run (#23546190140) on macos-15 — should pass end to end
- [ ] If smoke test fails in a future run, re-run with `skip_conversion = true` to retest without 1h+ conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)