### PR TITLE
fix: apply Qwen2.5 ChatML template to prevent repetition loops

### DIFF
--- a/ios/ZeldaGuide/Services/LLMService.swift
+++ b/ios/ZeldaGuide/Services/LLMService.swift
@@ -173,7 +173,7 @@ actor LLMService {
             return
         }
 
-        var inputTokens = tokenizer.encode(prompt)
+        var inputTokens = tokenizer.encode(ModelConfig.chatPrompt(userQuery: prompt))
         let eosID  = tokenizer.eosTokenID
         let maxNew = ModelConfig.maxOutputTokens
 

--- a/ios/ZeldaGuide/Services/ModelConfig.swift
+++ b/ios/ZeldaGuide/Services/ModelConfig.swift
@@ -45,4 +45,13 @@ struct ModelConfig {
         Be concise and specific.
         """
     }
+
+    /// Wraps a user query in the Qwen2.5 ChatML format required by the Instruct model.
+    /// Without this wrapper the model degenerates into repetition loops.
+    /// <|im_start|> = token 151644, <|im_end|> = token 151645 in the Qwen2.5 vocabulary.
+    static func chatPrompt(userQuery: String) -> String {
+        "<|im_start|>system\n\(systemPrompt)<|im_end|>\n" +
+        "<|im_start|>user\n\(userQuery)<|im_end|>\n" +
+        "<|im_start|>assistant\n"
+    }
 }

--- a/model/convert_llm.py
+++ b/model/convert_llm.py
@@ -106,11 +106,22 @@ def _assert_filename_sync(derived: str, from_config: str) -> None:
 
 
 def _assert_smoke_test(tokens: list, min_tokens: int = _SMOKE_TEST_MIN_TOKENS) -> None:
-    """Exit non-zero if the smoke test generated fewer tokens than expected."""
+    """Exit non-zero if the smoke test generated fewer tokens than expected,
+    or if output is degenerate (>= 80% identical tokens — repetition loop)."""
     if len(tokens) < min_tokens:
         print(
             f"ERROR: Smoke test generated only {len(tokens)} tokens "
             f"(expected >= {min_tokens}). The model may be broken.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    from collections import Counter
+    most_common_count = Counter(tokens).most_common(1)[0][1]
+    if most_common_count / len(tokens) >= 0.8:
+        print(
+            f"ERROR: Degenerate output — {most_common_count}/{len(tokens)} tokens are "
+            f"identical (token {Counter(tokens).most_common(1)[0][0]}). "
+            "The prompt is probably missing the chat template.",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -246,8 +257,17 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
     _assert_size(save_path, variant)
 
     # --- Smoke test: generate _SMOKE_TEST_MIN_TOKENS tokens ---
+    # Apply the Qwen2.5 ChatML template — the model is an Instruct model and
+    # degenerates (repetition loops) when fed a bare prompt without the wrapper.
     print(f"Running smoke test ({_SMOKE_TEST_MIN_TOKENS} tokens) …")
-    enc = tokenizer("What is the Hylian Shield?", return_tensors="pt")
+    messages = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user",   "content": "What is the Hylian Shield?"},
+    ]
+    input_text = tokenizer.apply_chat_template(
+        messages, tokenize=False, add_generation_prompt=True
+    )
+    enc = tokenizer(input_text, return_tensors="pt")
     input_ids = enc["input_ids"].numpy().astype(np.int32)
     attention_mask = enc["attention_mask"].numpy().astype(np.int32)
 

--- a/model/tests/test_convert_llm.py
+++ b/model/tests/test_convert_llm.py
@@ -126,6 +126,28 @@ def test_assert_smoke_test_exits_empty():
     assert exc.value.code == 1
 
 
+def test_assert_smoke_test_exits_degenerate():
+    # All tokens identical — the !!!!! repetition loop that prompted this fix.
+    tokens = [42] * _SMOKE_TEST_MIN_TOKENS
+    with pytest.raises(SystemExit) as exc:
+        _assert_smoke_test(tokens)
+    assert exc.value.code == 1
+
+
+def test_assert_smoke_test_exits_mostly_degenerate():
+    # 80 % identical tokens is still flagged.
+    tokens = [42] * 16 + [1, 2, 3, 4]   # 80 % token 42
+    with pytest.raises(SystemExit) as exc:
+        _assert_smoke_test(tokens)
+    assert exc.value.code == 1
+
+
+def test_assert_smoke_test_passes_varied():
+    # 75 % identical is below the 80 % threshold — should pass.
+    tokens = [42] * 15 + [1, 2, 3, 4, 5]   # 75 % token 42
+    _assert_smoke_test(tokens)  # must not raise
+
+
 # ---------------------------------------------------------------------------
 # _assert_size
 # ---------------------------------------------------------------------------
@@ -207,6 +229,11 @@ def _make_torch_mock():
     enc["attention_mask"].numpy.return_value = np.ones((1, 5), dtype=np.int32)
     tokenizer_mock.return_value = enc
     tokenizer_mock.decode.return_value = "A shield found in Hyrule Castle."
+    tokenizer_mock.apply_chat_template.return_value = (
+        "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
+        "<|im_start|>user\nWhat is the Hylian Shield?<|im_end|>\n"
+        "<|im_start|>assistant\n"
+    )
 
     torch_mock.float32 = "float32"
     torch_mock.float16 = "float16"
@@ -237,15 +264,22 @@ def _make_ct_mock():
 
 
 def _make_optimize_mock():
-    # Build logits that produce _SMOKE_TEST_MIN_TOKENS distinct tokens
+    # Build a predict side_effect that cycles through _SMOKE_TEST_MIN_TOKENS
+    # distinct token IDs so the new degenerate-output check doesn't fire.
     vocab_size = 32000
-    logits = np.zeros((1, 1, vocab_size), dtype=np.float32)
-    logits[0, 0, 42] = 1.0
+    call_counter = {"n": 0}
+
+    def _cycling_predict(inputs):
+        token_id = call_counter["n"] % _SMOKE_TEST_MIN_TOKENS
+        call_counter["n"] += 1
+        logits = np.zeros((1, 1, vocab_size), dtype=np.float32)
+        logits[0, 0, token_id] = 1.0
+        return {"logits": logits}
 
     # compressed_mock is returned by ct.convert() (torch-level palettization
     # means ct.convert() produces the final compressed model directly)
     compressed_mock = MagicMock()
-    compressed_mock.predict.return_value = {"logits": logits}
+    compressed_mock.predict.side_effect = _cycling_predict
     compressed_mock.save = MagicMock()
 
     # torch_optimize_mock represents coremltools.optimize.torch.palettization


### PR DESCRIPTION
## Problem
The smoke test was feeding the Instruct model a bare prompt (`"What is the Hylian Shield?"`). Qwen2.5-Instruct expects the ChatML format — without it the model enters a repetition loop. The last CI run produced `'!!!!!!!!!!!!!!!!!!!!'` and passed anyway because `_assert_smoke_test` only checked token count.

## Changes
**`convert_llm.py`**
- Apply `tokenizer.apply_chat_template()` before the smoke test inference loop
- Add degenerate-output check to `_assert_smoke_test`: exits with an error if ≥ 80% of generated tokens are identical — this would have caught the `!` loop immediately

**`ModelConfig.swift`**
- Add `chatPrompt(userQuery:)` static method that wraps the user query in the Qwen2.5 ChatML format (`<|im_start|>system…<|im_end|><|im_start|>user…<|im_end|><|im_start|>assistant\n`). Single place to update if the format ever changes.

**`LLMService.swift`**
- Call `ModelConfig.chatPrompt(userQuery: prompt)` in `runGeneration()` before tokenizing, so on-device inference uses the same correct format

**`test_convert_llm.py`**
- Add `test_assert_smoke_test_exits_degenerate`, `_exits_mostly_degenerate`, `_passes_varied`
- Wire `apply_chat_template` return value into the tokenizer mock
- Make the mock predictor cycle through distinct token IDs so the new degenerate check passes in the integration test

## Test plan
- [ ] `pytest model/tests/test_convert_llm.py` — 26/26 pass locally
- [ ] Re-run convert-model CI — smoke test output should be coherent text, not `!!!!!`

🤖 Generated with [Claude Code](https://claude.com/claude-code)