### PR TITLE
fix: set PYTHONPATH=. for smoke_test_llm.py step

### DIFF
--- a/.github/workflows/convert-model.yml
+++ b/.github/workflows/convert-model.yml
@@ -121,6 +121,8 @@ jobs:
 
       - name: Smoke test existing artifact
         if: ${{ github.event.inputs.skip_conversion == 'true' }}
+        env:
+          PYTHONPATH: .
         run: python model/smoke_test_llm.py --model-path "model/LlamaModel-${MODEL_VARIANT}.mlpackage"
 
       - name: Write job summary


### PR DESCRIPTION
smoke_test_llm.py does \ which needs the repo root on sys.path. pytest adds it automatically; direct python invocation doesn't. One-line fix.