### PR TITLE
refactor: rename LlamaModel → QwenModel throughout

### DIFF
--- a/.github/workflows/convert-model.yml
+++ b/.github/workflows/convert-model.yml
@@ -3,7 +3,7 @@
 #
 # Jobs:
 #   convert-embeddings  — all-MiniLM-L6-v2 → MiniLMEmbedder.mlpackage   (issue #8)
-#   convert-llm         — Qwen2.5 1B/3B     → LlamaModel.mlpackage        (issue #9)
+#   convert-llm         — Qwen2.5 1B/3B     → QwenModel.mlpackage        (issue #9)
 #
 # Inputs:
 #   model_variant      — "1B" (default) or "3B"
@@ -100,12 +100,12 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: python model/convert_llm.py --output-dir model/
 
-      - name: Upload LlamaModel artifact
+      - name: Upload QwenModel artifact
         if: ${{ github.event.inputs.skip_conversion != 'true' && always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: LlamaModel-${{ github.event.inputs.model_variant }}.mlpackage
-          path: model/LlamaModel-${{ github.event.inputs.model_variant }}.mlpackage
+          name: QwenModel-${{ github.event.inputs.model_variant }}.mlpackage
+          path: model/QwenModel-${{ github.event.inputs.model_variant }}.mlpackage
           retention-days: 30
 
       # --- Smoke-test-only path (skip_conversion = true) ---
@@ -114,8 +114,8 @@ jobs:
         if: ${{ github.event.inputs.skip_conversion == 'true' }}
         uses: actions/download-artifact@v4
         with:
-          name: LlamaModel-${{ github.event.inputs.model_variant }}.mlpackage
-          path: model/LlamaModel-${{ github.event.inputs.model_variant }}.mlpackage
+          name: QwenModel-${{ github.event.inputs.model_variant }}.mlpackage
+          path: model/QwenModel-${{ github.event.inputs.model_variant }}.mlpackage
           run-id: ${{ github.event.inputs.artifact_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -123,16 +123,16 @@ jobs:
         if: ${{ github.event.inputs.skip_conversion == 'true' }}
         env:
           PYTHONPATH: .
-        run: python model/smoke_test_llm.py --model-path "model/LlamaModel-${MODEL_VARIANT}.mlpackage"
+        run: python model/smoke_test_llm.py --model-path "model/QwenModel-${MODEL_VARIANT}.mlpackage"
 
       - name: Write job summary
         if: always()
         run: |
-          ARTIFACT="model/LlamaModel-${MODEL_VARIANT}.mlpackage"
+          ARTIFACT="model/QwenModel-${MODEL_VARIANT}.mlpackage"
           SIZE=$(du -sh "$ARTIFACT" 2>/dev/null | cut -f1 || echo "n/a")
           SKIPPED="${{ github.event.inputs.skip_conversion }}"
           echo "## LLM Conversion Summary" >> $GITHUB_STEP_SUMMARY
           echo "- Model variant: $MODEL_VARIANT" >> $GITHUB_STEP_SUMMARY
-          echo "- Output: LlamaModel-${MODEL_VARIANT}.mlpackage ($SIZE)" >> $GITHUB_STEP_SUMMARY
+          echo "- Output: QwenModel-${MODEL_VARIANT}.mlpackage ($SIZE)" >> $GITHUB_STEP_SUMMARY
           echo "- Conversion skipped: $SKIPPED" >> $GITHUB_STEP_SUMMARY
           echo "- Runner: macos-15" >> $GITHUB_STEP_SUMMARY

--- a/ios/ZeldaGuide/Services/ModelConfig.swift
+++ b/ios/ZeldaGuide/Services/ModelConfig.swift
@@ -1,33 +1,33 @@
 // ModelConfig.swift
 // THE single source of truth for the LLM variant.
 // To switch from 1B to 3B: change modelVariant to "3B", re-run the convert-model CI job,
-// and replace LlamaModel.mlpackage in Resources/. No other files need to change.
+// and replace QwenModel.mlpackage in Resources/. No other files need to change.
 
 import Foundation
 
 enum ModelVariant: String {
-    case llama1B = "1B"
-    case llama3B = "3B"
+    case qwen1B = "1B"
+    case qwen3B = "3B"
 }
 
 struct ModelConfig {
 
     // MARK: - Change this to switch model variants
-    static let activeVariant: ModelVariant = .llama1B
+    static let activeVariant: ModelVariant = .qwen1B
 
     // MARK: - Derived config (do not edit below this line)
 
     static var modelFilename: String {
         switch activeVariant {
-        case .llama1B: return "LlamaModel-1B.mlpackage"
-        case .llama3B: return "LlamaModel-3B.mlpackage"
+        case .qwen1B: return "QwenModel-1B.mlpackage"
+        case .qwen3B: return "QwenModel-3B.mlpackage"
         }
     }
 
     static var maxContextTokens: Int {
         switch activeVariant {
-        case .llama1B: return 4096
-        case .llama3B: return 8192
+        case .qwen1B: return 4096
+        case .qwen3B: return 8192
         }
     }
 

--- a/model/convert_llm.py
+++ b/model/convert_llm.py
@@ -3,7 +3,7 @@ convert_llm.py
 Converts Qwen2.5 1.5B or 3B Instruct from HuggingFace to a Core ML .mlpackage
 with 4-bit palettization quantization, for on-device inference on iOS.
 
-Output: model/LlamaModel-1B.mlpackage  or  model/LlamaModel-3B.mlpackage
+Output: model/QwenModel-1B.mlpackage  or  model/QwenModel-3B.mlpackage
   - Stateless model (full sequence passed each step, max 512 tokens)
   - 4-bit uniform palettization via coremltools.optimize.coreml
   - 1B output must be under 800 MB; 3B under 2 GB
@@ -61,7 +61,7 @@ def _derive_filename(variant: str) -> str:
             file=sys.stderr,
         )
         sys.exit(1)
-    return f"LlamaModel-{variant}.mlpackage"
+    return f"QwenModel-{variant}.mlpackage"
 
 
 def _parse_modelconfig_filename(swift_path: Path, variant: str) -> str:
@@ -69,10 +69,10 @@ def _parse_modelconfig_filename(swift_path: Path, variant: str) -> str:
     Read ModelConfig.swift and extract the modelFilename for the given variant.
 
     Looks for the pattern:
-        case .llama1B: return "LlamaModel-1B.mlpackage"
-        case .llama3B: return "LlamaModel-3B.mlpackage"
+        case .qwen1B: return "QwenModel-1B.mlpackage"
+        case .qwen3B: return "QwenModel-3B.mlpackage"
     """
-    swift_key = "llama1B" if variant == "1B" else "llama3B"
+    swift_key = "qwen1B" if variant == "1B" else "qwen3B"
     try:
         text = swift_path.read_text(encoding="utf-8")
     except FileNotFoundError:
@@ -291,7 +291,7 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
 # ---------------------------------------------------------------------------
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Convert Llama 3.2 to Core ML")
+    parser = argparse.ArgumentParser(description="Convert Qwen2.5 to Core ML")
     parser.add_argument(
         "--output-dir",
         default=str(Path(__file__).parent),

--- a/model/smoke_test_llm.py
+++ b/model/smoke_test_llm.py
@@ -1,6 +1,6 @@
 """
 smoke_test_llm.py
-Loads an existing LlamaModel .mlpackage and runs a structural smoke test:
+Loads an existing QwenModel .mlpackage and runs a structural smoke test:
 verifies the model loads, runs predict() without crashing, and produces the
 expected number of output tokens.
 
@@ -12,7 +12,7 @@ immediately after conversion in the same process where the model is still
 in memory and behaves correctly.
 
 Usage:
-    python model/smoke_test_llm.py --model-path model/LlamaModel-1B.mlpackage
+    python model/smoke_test_llm.py --model-path model/QwenModel-1B.mlpackage
 
 Environment variables:
     MODEL_VARIANT   "1B" (default) or "3B" — selects the tokenizer to load
@@ -49,7 +49,7 @@ def _assert_run(tokens: list, min_tokens: int = _SMOKE_TEST_MIN_TOKENS) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Structural smoke test for an existing LlamaModel .mlpackage")
+    parser = argparse.ArgumentParser(description="Structural smoke test for an existing QwenModel .mlpackage")
     parser.add_argument("--model-path", required=True, help="Path to the .mlpackage directory")
     args = parser.parse_args()
 

--- a/model/tests/test_convert_llm.py
+++ b/model/tests/test_convert_llm.py
@@ -28,11 +28,11 @@ from model.convert_llm import (
 # ---------------------------------------------------------------------------
 
 def test_derive_filename_1b():
-    assert _derive_filename("1B") == "LlamaModel-1B.mlpackage"
+    assert _derive_filename("1B") == "QwenModel-1B.mlpackage"
 
 
 def test_derive_filename_3b():
-    assert _derive_filename("3B") == "LlamaModel-3B.mlpackage"
+    assert _derive_filename("3B") == "QwenModel-3B.mlpackage"
 
 
 def test_derive_filename_invalid():
@@ -54,8 +54,8 @@ def test_derive_filename_empty_string():
 _FAKE_MODELCONFIG = """\
 static var modelFilename: String {
     switch activeVariant {
-    case .llama1B: return "LlamaModel-1B.mlpackage"
-    case .llama3B: return "LlamaModel-3B.mlpackage"
+    case .qwen1B: return "QwenModel-1B.mlpackage"
+    case .qwen3B: return "QwenModel-3B.mlpackage"
     }
 }
 """
@@ -64,13 +64,13 @@ static var modelFilename: String {
 def test_parse_modelconfig_filename_1b(tmp_path):
     swift_file = tmp_path / "ModelConfig.swift"
     swift_file.write_text(_FAKE_MODELCONFIG, encoding="utf-8")
-    assert _parse_modelconfig_filename(swift_file, "1B") == "LlamaModel-1B.mlpackage"
+    assert _parse_modelconfig_filename(swift_file, "1B") == "QwenModel-1B.mlpackage"
 
 
 def test_parse_modelconfig_filename_3b(tmp_path):
     swift_file = tmp_path / "ModelConfig.swift"
     swift_file.write_text(_FAKE_MODELCONFIG, encoding="utf-8")
-    assert _parse_modelconfig_filename(swift_file, "3B") == "LlamaModel-3B.mlpackage"
+    assert _parse_modelconfig_filename(swift_file, "3B") == "QwenModel-3B.mlpackage"
 
 
 def test_parse_modelconfig_filename_missing_file(tmp_path):
@@ -92,12 +92,12 @@ def test_parse_modelconfig_filename_pattern_absent(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_assert_filename_sync_passes():
-    _assert_filename_sync("LlamaModel-1B.mlpackage", "LlamaModel-1B.mlpackage")
+    _assert_filename_sync("QwenModel-1B.mlpackage", "QwenModel-1B.mlpackage")
 
 
 def test_assert_filename_sync_exits_on_mismatch():
     with pytest.raises(SystemExit) as exc:
-        _assert_filename_sync("LlamaModel-1B.mlpackage", "LlamaModel-WRONG.mlpackage")
+        _assert_filename_sync("QwenModel-1B.mlpackage", "QwenModel-WRONG.mlpackage")
     assert exc.value.code == 1
 
 
@@ -156,14 +156,14 @@ def test_assert_smoke_test_passes_varied():
 # ---------------------------------------------------------------------------
 
 def test_assert_size_passes_small_file(tmp_path):
-    pkg = tmp_path / "LlamaModel-1B.mlpackage"
+    pkg = tmp_path / "QwenModel-1B.mlpackage"
     pkg.mkdir()
     (pkg / "weights.bin").write_bytes(b"x" * 1024)  # 1 KB
     _assert_size(pkg, "1B")  # well under 700 MB
 
 
 def test_assert_size_exits_1b_over_limit(tmp_path):
-    pkg = tmp_path / "LlamaModel-1B.mlpackage"
+    pkg = tmp_path / "QwenModel-1B.mlpackage"
     pkg.mkdir()
     limit_1b = 800 * 1024 * 1024
     # Patch stat to report oversized file without writing gigabytes
@@ -179,7 +179,7 @@ def test_assert_size_exits_1b_over_limit(tmp_path):
 
 
 def test_assert_size_exits_3b_over_limit(tmp_path):
-    pkg = tmp_path / "LlamaModel-3B.mlpackage"
+    pkg = tmp_path / "QwenModel-3B.mlpackage"
     pkg.mkdir()
     limit_3b = 2 * 1024 * 1024 * 1024
     fake_file = MagicMock()
@@ -194,7 +194,7 @@ def test_assert_size_exits_3b_over_limit(tmp_path):
 
 
 def test_assert_size_passes_3b_under_limit(tmp_path):
-    pkg = tmp_path / "LlamaModel-3B.mlpackage"
+    pkg = tmp_path / "QwenModel-3B.mlpackage"
     pkg.mkdir()
     (pkg / "weights.bin").write_bytes(b"x" * 1024)
     _assert_size(pkg, "3B")
@@ -356,14 +356,14 @@ def test_convert_saves_correct_filename(_patch_heavy):
     tmp_path, _, _, compressed_mock = _patch_heavy
     from model.convert_llm import convert
     convert(str(tmp_path), "1B", "fake-token")
-    compressed_mock.save.assert_called_once_with(str(tmp_path / "LlamaModel-1B.mlpackage"))
+    compressed_mock.save.assert_called_once_with(str(tmp_path / "QwenModel-1B.mlpackage"))
 
 
 def test_convert_exits_on_filename_mismatch(_patch_heavy):
     tmp_path, _, _, _ = _patch_heavy
     from model.convert_llm import convert
     with patch("model.convert_llm._parse_modelconfig_filename",
-               return_value="LlamaModel-WRONG.mlpackage"):
+               return_value="QwenModel-WRONG.mlpackage"):
         with pytest.raises(SystemExit) as exc:
             convert(str(tmp_path), "1B", "fake-token")
     assert exc.value.code == 1


### PR DESCRIPTION
## Summary
- Renames `.mlpackage` filename from `LlamaModel-{variant}` to `QwenModel-{variant}` — the model is Qwen2.5, not Llama
- Swift enum cases: `llama1B`/`llama3B` → `qwen1B`/`qwen3B`
- Updated everywhere: `ModelConfig.swift`, `convert_llm.py`, `smoke_test_llm.py`, `convert-model.yml`, `test_convert_llm.py`

## No rerun required
The next conversion run will produce `QwenModel-1B.mlpackage` automatically. The existing artifact from run 23558521205 remains valid under its old name until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)