### PR TITLE
Fix Xcode build errors blocking .ipa generation

### DIFF
--- a/ios/ZeldaGuide.xcodeproj/project.pbxproj
+++ b/ios/ZeldaGuide.xcodeproj/project.pbxproj
@@ -21,6 +21,11 @@
 		AC1000000000000000000002 /* LLMServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2000000000000000000002 /* LLMServiceTests.swift */; };
 		AD1000000000000000000001 /* RAGEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2000000000000000000001 /* RAGEngine.swift */; };
 		AD1000000000000000000002 /* RAGEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD2000000000000000000002 /* RAGEngineTests.swift */; };
+		AE1000000000000000000001 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2000000000000000000001 /* ChatView.swift */; };
+		AF1000000000000000000001 /* MessageBubbleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF2000000000000000000001 /* MessageBubbleView.swift */; };
+		AG1000000000000000000001 /* SourceAttributionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AG2000000000000000000001 /* SourceAttributionView.swift */; };
+		AH1000000000000000000001 /* ChatViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AH2000000000000000000001 /* ChatViewModel.swift */; };
+		AI1000000000000000000001 /* ChatViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AI2000000000000000000001 /* ChatViewModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -38,6 +43,11 @@
 		AC2000000000000000000002 /* LLMServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMServiceTests.swift; sourceTree = "<group>"; };
 		AD2000000000000000000001 /* RAGEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAGEngine.swift; sourceTree = "<group>"; };
 		AD2000000000000000000002 /* RAGEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RAGEngineTests.swift; sourceTree = "<group>"; };
+		AE2000000000000000000001 /* ChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatView.swift; sourceTree = "<group>"; };
+		AF2000000000000000000001 /* MessageBubbleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBubbleView.swift; sourceTree = "<group>"; };
+		AG2000000000000000000001 /* SourceAttributionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SourceAttributionView.swift; sourceTree = "<group>"; };
+		AH2000000000000000000001 /* ChatViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModel.swift; sourceTree = "<group>"; };
+		AI2000000000000000000001 /* ChatViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatViewModelTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -88,6 +98,7 @@
 				AB1000000000000000000003 /* VectorSearchServiceTests.swift in Sources */,
 				AC1000000000000000000002 /* LLMServiceTests.swift in Sources */,
 				AD1000000000000000000002 /* RAGEngineTests.swift in Sources */,
+				AI1000000000000000000001 /* ChatViewModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,6 +130,9 @@
 			isa = PBXGroup;
 			children = (
 				AA2000000000000000000002 /* ContentView.swift */,
+				AE2000000000000000000001 /* ChatView.swift */,
+				AF2000000000000000000001 /* MessageBubbleView.swift */,
+				AG2000000000000000000001 /* SourceAttributionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -138,6 +152,7 @@
 			isa = PBXGroup;
 			children = (
 				AB2000000000000000000001 /* KnowledgeChunk.swift */,
+				AH2000000000000000000001 /* ChatViewModel.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -148,6 +163,7 @@
 				AB2000000000000000000003 /* VectorSearchServiceTests.swift */,
 				AC2000000000000000000002 /* LLMServiceTests.swift */,
 				AD2000000000000000000002 /* RAGEngineTests.swift */,
+				AI2000000000000000000001 /* ChatViewModelTests.swift */,
 			);
 			path = ZeldaGuideTests;
 			sourceTree = "<group>";
@@ -279,6 +295,10 @@
 				AB1000000000000000000002 /* VectorSearchService.swift in Sources */,
 				AC1000000000000000000001 /* LLMService.swift in Sources */,
 				AD1000000000000000000001 /* RAGEngine.swift in Sources */,
+				AE1000000000000000000001 /* ChatView.swift in Sources */,
+				AF1000000000000000000001 /* MessageBubbleView.swift in Sources */,
+				AG1000000000000000000001 /* SourceAttributionView.swift in Sources */,
+				AH1000000000000000000001 /* ChatViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/ZeldaGuide/Services/LLMService.swift
+++ b/ios/ZeldaGuide/Services/LLMService.swift
@@ -61,7 +61,7 @@ struct CoreMLPredictor: LLMPredictor {
             "input_ids":      MLFeatureValue(multiArray: inputArr),
             "attention_mask": MLFeatureValue(multiArray: maskArr),
         ])
-        let result = try model.prediction(from: features)
+        let result = try await model.prediction(from: features)
         guard let mla = result.featureValue(for: "logits")?.multiArrayValue else {
             throw LLMError.loadFailed(NSError(
                 domain: "LLMService", code: -1,
@@ -85,9 +85,8 @@ struct BundledTokenizer: LLMTokenizer {
     }
 
     func decode(tokenID: Int32) -> String {
-        guard tokenID >= 0, tokenID < 256,
-              let scalar = Unicode.Scalar(UInt8(tokenID)) else { return "" }
-        return String(scalar)
+        guard tokenID >= 0, tokenID < 256 else { return "" }
+        return String(Unicode.Scalar(UInt8(tokenID)))
     }
 }
 

--- a/ios/ZeldaGuide/Services/RAGEngine.swift
+++ b/ios/ZeldaGuide/Services/RAGEngine.swift
@@ -86,7 +86,7 @@ actor CoreMLEmbeddingService: EmbeddingService {
             "input_ids":      MLFeatureValue(multiArray: inputIDs),
             "attention_mask": MLFeatureValue(multiArray: attentionMask),
         ])
-        let result = try model.prediction(from: features)
+        let result = try await model.prediction(from: features)
 
         // all-MiniLM-L6-v2 exported via coremltools uses "sentence_embedding"; fall back
         // to "embeddings" if the export script used a different output name.


### PR DESCRIPTION
## Summary
- `project.pbxproj`: registers 5 files that existed on disk but were missing from the Xcode project — `ChatView.swift`, `MessageBubbleView.swift`, `SourceAttributionView.swift`, `ChatViewModel.swift`, `ChatViewModelTests.swift` (all written in milestones 3/#15/#16)
- `LLMService.swift`: add `await` to `model.prediction(from:)` (async in current Core ML SDK); fix `Unicode.Scalar(UInt8(_))` `if let` guard — this initialiser is non-optional
- `RAGEngine.swift`: add `await` to `model.prediction(from:)`

## Test plan
- [ ] Build iOS .ipa workflow passes (exit code 0, artifact produced)
- [ ] Run summary shows correct model variant and size

🤖 Generated with [Claude Code](https://claude.com/claude-code)