### PR TITLE
Fix: compile .mlpackage at runtime before loading

### DIFF
--- a/ios/ZeldaGuide/Services/LLMService.swift
+++ b/ios/ZeldaGuide/Services/LLMService.swift
@@ -128,7 +128,8 @@ actor LLMService {
         do {
             let config = MLModelConfiguration()
             config.computeUnits = .cpuAndNeuralEngine
-            let model = try await MLModel.load(contentsOf: modelURL, configuration: config)
+            let compiledURL = try await compileAndCache(modelURL)
+            let model = try await MLModel.load(contentsOf: compiledURL, configuration: config)
             predictor = CoreMLPredictor(model: model)
         } catch let e as LLMError {
             throw e
@@ -138,6 +139,21 @@ actor LLMService {
 
         tokenizer = BundledTokenizer()
         registerMemoryWarningHandler()
+    }
+
+    /// Compiles a .mlpackage to a .mlmodelc and caches it in Library/Caches.
+    /// Subsequent calls return the cached URL immediately.
+    private func compileAndCache(_ sourceURL: URL) async throws -> URL {
+        let fm = FileManager.default
+        let cacheDir = fm.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("CompiledModels", isDirectory: true)
+        let cachedURL = cacheDir.appendingPathComponent(sourceURL.lastPathComponent + "c")
+        if fm.fileExists(atPath: cachedURL.path) { return cachedURL }
+        try fm.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        let tmpURL = try await MLModel.compileModel(at: sourceURL)
+        try? fm.removeItem(at: cachedURL)
+        try fm.moveItem(at: tmpURL, to: cachedURL)
+        return cachedURL
     }
 
     // MARK: - Generation

--- a/ios/ZeldaGuide/Services/RAGEngine.swift
+++ b/ios/ZeldaGuide/Services/RAGEngine.swift
@@ -54,10 +54,26 @@ actor CoreMLEmbeddingService: EmbeddingService {
         do {
             let config = MLModelConfiguration()
             config.computeUnits = .cpuAndNeuralEngine
-            model = try await MLModel.load(contentsOf: modelURL, configuration: config)
+            let compiledURL = try await compileAndCache(modelURL)
+            model = try await MLModel.load(contentsOf: compiledURL, configuration: config)
         } catch {
             throw EmbeddingError.loadFailed(error)
         }
+    }
+
+    /// Compiles a .mlpackage to a .mlmodelc and caches it in Library/Caches.
+    /// Subsequent calls return the cached URL immediately.
+    private func compileAndCache(_ sourceURL: URL) async throws -> URL {
+        let fm = FileManager.default
+        let cacheDir = fm.urls(for: .cachesDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("CompiledModels", isDirectory: true)
+        let cachedURL = cacheDir.appendingPathComponent(sourceURL.lastPathComponent + "c")
+        if fm.fileExists(atPath: cachedURL.path) { return cachedURL }
+        try fm.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        let tmpURL = try await MLModel.compileModel(at: sourceURL)
+        try? fm.removeItem(at: cachedURL)
+        try fm.moveItem(at: tmpURL, to: cachedURL)
+        return cachedURL
     }
 
     /// Embeds `text` using the Core ML all-MiniLM-L6-v2 model.


### PR DESCRIPTION
## Problem
`[Error: Failed to load embedding model: Unable to load model... Compile the model with Xcode or MLModel.compileModel(at:)]`

`MLModel.load(contentsOf:)` expects a compiled `.mlmodelc`, not a raw `.mlpackage`. The bundled models have `lastKnownFileType = folder` in the Xcode project so Xcode doesn't compile them at build time.

## Fix
Add `compileAndCache(_:)` to both `CoreMLEmbeddingService` and `LLMService`. On first launch it compiles the `.mlpackage` via `MLModel.compileModel(at:)` and moves the result to `Library/Caches/CompiledModels/`. Subsequent launches skip compilation and load from cache directly.

## Test plan
- [ ] Build iOS .ipa passes
- [ ] First launch after install: embedding model compiles (may take a few seconds before first answer)
- [ ] Second question answers without compilation delay
- [ ] App still works after clearing caches (recompiles cleanly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)