### PR TITLE
fix: bundle real Core ML models in .ipa

### DIFF
--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -35,6 +35,10 @@ on:
         default: '1B'
         type: choice
         options: ['1B', '3B']
+      llm_run_id:
+        description: 'Run ID of convert-model.yml that produced the QwenModel artifact'
+        required: true
+        type: string
 
 jobs:
   build-ipa:
@@ -42,6 +46,32 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: model/requirements.txt
+
+      - name: Install model conversion dependencies
+        run: pip install -r model/requirements.txt
+
+      - name: Convert embedding model (MiniLMEmbedder)
+        run: python model/convert_embeddings.py --output-dir model/
+
+      - name: Inject MiniLMEmbedder into Resources
+        run: |
+          rm -rf ios/ZeldaGuide/Resources/MiniLMEmbedder.mlpackage
+          cp -r model/MiniLMEmbedder.mlpackage ios/ZeldaGuide/Resources/MiniLMEmbedder.mlpackage
+
+      - name: Download QwenModel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: QwenModel-${{ inputs.model_variant }}.mlpackage
+          path: ios/ZeldaGuide/Resources/QwenModel-${{ inputs.model_variant }}.mlpackage
+          run-id: ${{ inputs.llm_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Archive (unsigned)
         run: |

--- a/ios/ZeldaGuide.xcodeproj/project.pbxproj
+++ b/ios/ZeldaGuide.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		AA1000000000000000000003 /* ModelConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA2000000000000000000003 /* ModelConfig.swift */; };
 		AA1000000000000000000004 /* knowledge_base.db in Resources */ = {isa = PBXBuildFile; fileRef = AA2000000000000000000004 /* knowledge_base.db */; };
 		AA1000000000000000000005 /* MiniLMEmbedder.mlpackage in Resources */ = {isa = PBXBuildFile; fileRef = AA2000000000000000000005 /* MiniLMEmbedder.mlpackage */; };
+		AA1000000000000000000007 /* QwenModel-1B.mlpackage in Resources */ = {isa = PBXBuildFile; fileRef = AA2000000000000000000007 /* QwenModel-1B.mlpackage */; };
 		AA1000000000000000000006 /* SQLiteVec in Frameworks */ = {isa = PBXBuildFile; productRef = AAC000000000000000000001 /* SQLiteVec */; };
 		AB1000000000000000000001 /* KnowledgeChunk.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000000000000000000001 /* KnowledgeChunk.swift */; };
 		AB1000000000000000000002 /* VectorSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2000000000000000000002 /* VectorSearchService.swift */; };
@@ -35,6 +36,7 @@
 		AA2000000000000000000003 /* ModelConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelConfig.swift; sourceTree = "<group>"; };
 		AA2000000000000000000004 /* knowledge_base.db */ = {isa = PBXFileReference; lastKnownFileType = file; path = knowledge_base.db; sourceTree = "<group>"; };
 		AA2000000000000000000005 /* MiniLMEmbedder.mlpackage */ = {isa = PBXFileReference; lastKnownFileType = folder; path = MiniLMEmbedder.mlpackage; sourceTree = "<group>"; };
+		AA2000000000000000000007 /* QwenModel-1B.mlpackage */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "QwenModel-1B.mlpackage"; sourceTree = "<group>"; };
 		AA2000000000000000000006 /* ZeldaGuide.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ZeldaGuide.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB2000000000000000000001 /* KnowledgeChunk.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KnowledgeChunk.swift; sourceTree = "<group>"; };
 		AB2000000000000000000002 /* VectorSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VectorSearchService.swift; sourceTree = "<group>"; };
@@ -176,6 +178,7 @@
 			children = (
 				AA2000000000000000000004 /* knowledge_base.db */,
 				AA2000000000000000000005 /* MiniLMEmbedder.mlpackage */,
+				AA2000000000000000000007 /* QwenModel-1B.mlpackage */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -281,6 +284,7 @@
 			files = (
 				AA1000000000000000000004 /* knowledge_base.db in Resources */,
 				AA1000000000000000000005 /* MiniLMEmbedder.mlpackage in Resources */,
+				AA1000000000000000000007 /* QwenModel-1B.mlpackage in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/ZeldaGuide/Resources/QwenModel-1B.mlpackage/Manifest.json
+++ b/ios/ZeldaGuide/Resources/QwenModel-1B.mlpackage/Manifest.json
@@ -1,0 +1,13 @@
+{
+  "fileFormatVersion": "1.0.0",
+  "itemInfoEntries": {
+    "0": {
+      "author": "placeholder",
+      "description": "Placeholder – replace with CI artifact from convert-llm job in convert-model.yml",
+      "name": "QwenModel-1B",
+      "path": "Data/com.apple.CoreML",
+      "type": "coremldata"
+    }
+  },
+  "rootItemIdentifier": "0"
+}


### PR DESCRIPTION
Closes #66

## Summary
- `build-ipa.yml` now runs `convert_embeddings.py` inline to generate a real `MiniLMEmbedder.mlpackage` before building, replacing the placeholder that caused `Item does not exist for identifier: 0`
- `build-ipa.yml` accepts a new `llm_run_id` input and downloads `QwenModel-{variant}.mlpackage` from a prior `convert-model.yml` run before building
- Added `QwenModel-1B.mlpackage` placeholder to `ios/ZeldaGuide/Resources/` and `project.pbxproj` so the LLM is referenced in the Xcode project and bundled in the `.app`

## How to use
1. Run `Convert Core ML model` workflow (if you haven't recently) — note the **Run ID**
2. Run `Build iOS .ipa` workflow, set `model_variant=1B` and paste the **Run ID** into `llm_run_id`
3. The build will convert the embedder fresh and download the real LLM artifact before archiving

## Test plan
- [ ] Trigger `build-ipa.yml` with a valid `llm_run_id` from a prior `convert-model.yml` run
- [ ] Install the resulting `.ipa` via SideStore
- [ ] Ask a question — should get a real answer, not an embedding error

🤖 Generated with [Claude Code](https://claude.com/claude-code)