### PR TITLE
fix: pad embedding input to fixed seq length 128

### DIFF
--- a/ios/ZeldaGuide/Services/RAGEngine.swift
+++ b/ios/ZeldaGuide/Services/RAGEngine.swift
@@ -86,16 +86,18 @@ actor CoreMLEmbeddingService: EmbeddingService {
                 userInfo: [NSLocalizedDescriptionKey: "Model unavailable after load"]))
         }
 
-        // Placeholder tokenisation: UTF-8 bytes mapped to token IDs, clamped to 128 tokens.
+        // Placeholder tokenisation: UTF-8 bytes mapped to token IDs.
         // Replace with a proper BPE tokeniser once tokenizer.json is bundled from CI.
-        let tokens = Array(text.utf8.prefix(128)).map { Int32($0) }
-        let seqLen = max(1, tokens.count)
+        // The model was traced with a fixed seq length of 128 — always pad to that length.
+        let fixedLen = 128
+        let rawTokens = Array(text.utf8.prefix(fixedLen)).map { Int32($0) }
+        let realLen   = rawTokens.count
 
-        let inputIDs      = try MLMultiArray(shape: [1, NSNumber(value: seqLen)], dataType: .int32)
-        let attentionMask = try MLMultiArray(shape: [1, NSNumber(value: seqLen)], dataType: .int32)
-        for i in 0..<seqLen {
-            inputIDs[i]      = NSNumber(value: tokens[i])
-            attentionMask[i] = 1
+        let inputIDs      = try MLMultiArray(shape: [1, NSNumber(value: fixedLen)], dataType: .int32)
+        let attentionMask = try MLMultiArray(shape: [1, NSNumber(value: fixedLen)], dataType: .int32)
+        for i in 0..<fixedLen {
+            inputIDs[i]      = i < realLen ? NSNumber(value: rawTokens[i]) : 0
+            attentionMask[i] = i < realLen ? 1 : 0
         }
 
         let features = try MLDictionaryFeatureProvider(dictionary: [


### PR DESCRIPTION
Closes #70

## Summary
- `CoreMLEmbeddingService.embed()` was creating `MLMultiArray` with shape `[1, actualTokenCount]` (e.g. 40 for a short query)
- The model was converted with `max_length=128` in `convert_embeddings.py`, so Core ML expects exactly `[1, 128]`
- Fix: always allocate `[1, 128]` arrays; zero-pad `input_ids` and set `attention_mask=0` for padding positions

## Test plan
- [ ] Merge and trigger `build-ipa.yml` with `llm_run_id=23563734620`
- [ ] Install via SideStore, ask a question — should get an answer instead of a shape error

🤖 Generated with [Claude Code](https://claude.com/claude-code)