### PR TITLE
ci: add workflow_dispatch trigger to test-ios.yml

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -8,6 +8,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
Adds `workflow_dispatch` so the iOS simulator tests can be triggered on demand without needing a push or PR.

Closes #74 (if one exists, otherwise just a utility change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)