### PR TITLE
fix: look up 'embedding' output key from CoreML embedder

### DIFF
--- a/ios/ZeldaGuide/Services/RAGEngine.swift
+++ b/ios/ZeldaGuide/Services/RAGEngine.swift
@@ -110,12 +110,13 @@ actor CoreMLEmbeddingService: EmbeddingService {
         ])
         let result = try await model.prediction(from: features)
 
-        // all-MiniLM-L6-v2 exported via coremltools uses "sentence_embedding"; fall back
-        // to "embeddings" if the export script used a different output name.
-        guard let mla = result.featureValue(for: "sentence_embedding")?.multiArrayValue
+        // coremltools names the output based on the ct.TensorType name passed at conversion time.
+        // Our convert_embeddings.py uses "embedding"; fall back to legacy names for older builds.
+        guard let mla = result.featureValue(for: "embedding")?.multiArrayValue
+                     ?? result.featureValue(for: "sentence_embedding")?.multiArrayValue
                      ?? result.featureValue(for: "embeddings")?.multiArrayValue else {
             throw EmbeddingError.invalidOutput(
-                "Model output missing expected key ('sentence_embedding' or 'embeddings')")
+                "Model output missing expected key ('embedding', 'sentence_embedding', or 'embeddings')")
         }
 
         let dims      = ModelConfig.embeddingDimensions


### PR DESCRIPTION
Closes #75

## Problem
`convert_embeddings.py` names the Core ML output `"embedding"` (line 119), but `RAGEngine.swift` only checked for `"sentence_embedding"` or `"embeddings"`. Every query threw:

> Model output missing expected key ('sentence_embedding' or 'embeddings')

## Fix
Add `"embedding"` as the primary key to check, keeping the old names as fallbacks for older builds.

No CI re-run needed — the existing `.mlpackage` artifact already uses `"embedding"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)