### PR TITLE
fix: compile Core ML models with --target-platform iphoneos (#85)

### DIFF
--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -69,7 +69,8 @@ jobs:
 
       - name: Compile MiniLMEmbedder to .mlmodelc and inject into Resources
         run: |
-          xcrun coremlcompiler compile model/MiniLMEmbedder.mlpackage model/
+          xcrun coremlcompiler compile model/MiniLMEmbedder.mlpackage model/ \
+            --target-platform iphoneos --deployment-target 18.0
           rm -rf ios/ZeldaGuide/Resources/MiniLMEmbedder.mlmodelc
           mv model/MiniLMEmbedder.mlmodelc ios/ZeldaGuide/Resources/MiniLMEmbedder.mlmodelc
 
@@ -86,7 +87,8 @@ jobs:
           VARIANT="${{ inputs.model_variant }}"
           xcrun coremlcompiler compile \
             "ios/ZeldaGuide/Resources/QwenModel-${VARIANT}.mlpackage" \
-            "ios/ZeldaGuide/Resources/"
+            "ios/ZeldaGuide/Resources/" \
+            --target-platform iphoneos --deployment-target 18.0
           rm -rf "ios/ZeldaGuide/Resources/QwenModel-${VARIANT}.mlpackage"
 
       - name: Download tokenizer.json artifact

--- a/.github/workflows/debug-simulator.yml
+++ b/.github/workflows/debug-simulator.yml
@@ -57,7 +57,8 @@ jobs:
 
       - name: Compile MiniLMEmbedder to .mlmodelc and inject into Resources
         run: |
-          xcrun coremlcompiler compile model/MiniLMEmbedder.mlpackage model/
+          xcrun coremlcompiler compile model/MiniLMEmbedder.mlpackage model/ \
+            --target-platform iphonesimulator --deployment-target 18.0
           rm -rf ios/ZeldaGuide/Resources/MiniLMEmbedder.mlmodelc
           mv model/MiniLMEmbedder.mlmodelc ios/ZeldaGuide/Resources/MiniLMEmbedder.mlmodelc
 
@@ -74,7 +75,8 @@ jobs:
           VARIANT="${{ inputs.model_variant }}"
           xcrun coremlcompiler compile \
             "ios/ZeldaGuide/Resources/QwenModel-${VARIANT}.mlpackage" \
-            "ios/ZeldaGuide/Resources/"
+            "ios/ZeldaGuide/Resources/" \
+            --target-platform iphonesimulator --deployment-target 18.0
           rm -rf "ios/ZeldaGuide/Resources/QwenModel-${VARIANT}.mlpackage"
 
       - name: Download tokenizer.json artifact


### PR DESCRIPTION
Closes #85

## What

`xcrun coremlcompiler compile` defaults to macOS as the target platform. The resulting `.mlmodelc` loads fine on the macOS simulator but fails on a physical iOS device with:

> LLM unavailable: Failed to load LLM: The data couldn't be read because it isn't in the correct format

## Fix

Add `--target-platform iphoneos --deployment-target 18.0` to both `coremlcompiler compile` calls in `build-ipa.yml` (MiniLMEmbedder + QwenModel). `debug-simulator.yml` gets `iphonesimulator` instead.

No Swift code changes needed — the `.mlmodelc` bundle format is identical, only the compiled kernels inside differ between platforms.