### PR TITLE
fix: use --platform flag for coremlcompiler (fixes #85)

### DIFF
--- a/.github/workflows/build-ipa.yml
+++ b/.github/workflows/build-ipa.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Compile MiniLMEmbedder to .mlmodelc and inject into Resources
         run: |
           xcrun coremlcompiler compile model/MiniLMEmbedder.mlpackage model/ \
-            --target-platform iphoneos --deployment-target 18.0
+            --platform iphoneos --deployment-target 18.0
           rm -rf ios/ZeldaGuide/Resources/MiniLMEmbedder.mlmodelc
           mv model/MiniLMEmbedder.mlmodelc ios/ZeldaGuide/Resources/MiniLMEmbedder.mlmodelc
 
@@ -88,7 +88,7 @@ jobs:
           xcrun coremlcompiler compile \
             "ios/ZeldaGuide/Resources/QwenModel-${VARIANT}.mlpackage" \
             "ios/ZeldaGuide/Resources/" \
-            --target-platform iphoneos --deployment-target 18.0
+            --platform iphoneos --deployment-target 18.0
           rm -rf "ios/ZeldaGuide/Resources/QwenModel-${VARIANT}.mlpackage"
 
       - name: Download tokenizer.json artifact

--- a/.github/workflows/debug-simulator.yml
+++ b/.github/workflows/debug-simulator.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Compile MiniLMEmbedder to .mlmodelc and inject into Resources
         run: |
           xcrun coremlcompiler compile model/MiniLMEmbedder.mlpackage model/ \
-            --target-platform iphonesimulator --deployment-target 18.0
+            --platform iphonesimulator --deployment-target 18.0
           rm -rf ios/ZeldaGuide/Resources/MiniLMEmbedder.mlmodelc
           mv model/MiniLMEmbedder.mlmodelc ios/ZeldaGuide/Resources/MiniLMEmbedder.mlmodelc
 
@@ -76,7 +76,7 @@ jobs:
           xcrun coremlcompiler compile \
             "ios/ZeldaGuide/Resources/QwenModel-${VARIANT}.mlpackage" \
             "ios/ZeldaGuide/Resources/" \
-            --target-platform iphonesimulator --deployment-target 18.0
+            --platform iphonesimulator --deployment-target 18.0
           rm -rf "ios/ZeldaGuide/Resources/QwenModel-${VARIANT}.mlpackage"
 
       - name: Download tokenizer.json artifact


### PR DESCRIPTION
Closes #85

r19 logs showed `--target-platform` was silently ignored:
```
Warning: ignoring unrecognized command line argument --target-platform iphoneos
coremlcompiler: warning: compile command both --platform AND --deployment-target must be provided
```

The correct flag is `--platform`. With `--platform iphoneos --deployment-target 18.0` the compiler will produce an iOS-compatible `.mlmodelc` instead of the default macOS target.