### PR TITLE
fix: extend debug-simulator wait timeout from 20 min to 45 min

### DIFF
--- a/.github/workflows/debug-simulator.yml
+++ b/.github/workflows/debug-simulator.yml
@@ -39,8 +39,8 @@ jobs:
     permissions:
       contents: read
       actions: read
-    # Model compilation: 30–60 min. App load + RAG: up to 20 min.
-    timeout-minutes: 100
+    # Model compilation: 30–60 min. App load (2048-context cpuOnly) + RAG: up to 45 min.
+    timeout-minutes: 120
     steps:
       - uses: actions/checkout@v4
 
@@ -170,16 +170,17 @@ jobs:
             --autoquery 2>&1
           echo "App launched with --autoquery"
 
-      - name: Wait for RAG pipeline to complete (up to 20 min)
+      - name: Wait for RAG pipeline to complete (up to 45 min)
         run: |
           # Poll until we see a [CI-AUTOQUERY] result, a crash report, or timeout.
-          # Model load: 5–15 min on simulator. RAG query: ~1 min on top.
+          # Model load: up to 35 min for 2048-context cpuOnly model on simulator.
+          # RAG query: ~1–2 min on top. 270 * 10s = 45 min total.
           # We do NOT use 'ps ax' via simctl spawn — process names appear differently
           # inside the container and produce false "process gone" reports.
           # Instead we check for a crash report file as the reliable crash signal.
           CRASH_DIR="$HOME/Library/Logs/DiagnosticReports"
           echo "Waiting for [CI-AUTOQUERY] PASS or FAIL..."
-          for i in $(seq 1 120); do
+          for i in $(seq 1 270); do
             sleep 10
             echo "--- elapsed: ${i}0s ---"
             # Stop if a crash report appeared.


### PR DESCRIPTION
## Summary
- The 2048-context cpuOnly LLM (run 23591992777) takes >20 minutes to load in the iOS simulator, causing the [CI-AUTOQUERY] poll loop to time out before the model finishes loading
- Extends the wait loop from 120 × 10s (20 min) to 270 × 10s (45 min)
- Raises the job `timeout-minutes` from 100 to 120 to accommodate the longer wait

## Diagnosis
Run 23599983164 showed the model weights were mmapped at 14:40:05, but no [CI-AUTOQUERY] marker appeared before the 20-minute timeout at 15:00:02. The app was still alive (no crash reports) — it was simply still loading the 774MB model with `cpuOnly` compute units.

## Test plan
- [ ] Merge this PR
- [ ] Re-trigger debug-simulator with llm_run_id=23591992777 tokenizer_run_id=23587143619 model_variant=1B
- [ ] Confirm [CI-AUTOQUERY] PASS appears before the 45-min timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)