### PR TITLE
fix: use --stdout=path syntax for simctl launch

### DIFF
--- a/.github/workflows/debug-simulator.yml
+++ b/.github/workflows/debug-simulator.yml
@@ -168,8 +168,8 @@ jobs:
           # is ready and print a [CI-AUTOQUERY] PASS/FAIL line we can grep for below.
           # --stdout captures Swift print() output (os_log goes to simulator.log via log stream).
           xcrun simctl launch \
-            --stdout "$RUNNER_TEMP/app_stdout.log" \
-            --stderr "$RUNNER_TEMP/app_stdout.log" \
+            "--stdout=$RUNNER_TEMP/app_stdout.log" \
+            "--stderr=$RUNNER_TEMP/app_stdout.log" \
             "${{ env.SIMULATOR_UDID }}" com.tlo300.ZeldaGuide \
             --autoquery
           echo "App launched with --autoquery"


### PR DESCRIPTION
`simctl launch` requires `--stdout=<path>` (equals sign). Using a space caused simctl to treat `--stdout` as the device UDID argument, giving `Invalid device: --stdout` and an immediate exit code 148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)