### PR TITLE
fix: use Logger (os_log) for CI output instead of print()

### DIFF
--- a/.github/workflows/debug-simulator.yml
+++ b/.github/workflows/debug-simulator.yml
@@ -165,13 +165,8 @@ jobs:
       - name: Launch app on simulator
         run: |
           # --autoquery tells ChatViewModel to auto-submit a test question after the engine
-          # is ready and print a [CI-AUTOQUERY] PASS/FAIL line we can grep for below.
-          # --stdout captures Swift print() output (os_log goes to simulator.log via log stream).
-          xcrun simctl launch \
-            "--stdout=$RUNNER_TEMP/app_stdout.log" \
-            "--stderr=$RUNNER_TEMP/app_stdout.log" \
-            "${{ env.SIMULATOR_UDID }}" com.tlo300.ZeldaGuide \
-            --autoquery
+          # is ready and emit a [CI-AUTOQUERY] PASS/FAIL line via Logger (captured by log stream).
+          xcrun simctl launch "${{ env.SIMULATOR_UDID }}" com.tlo300.ZeldaGuide --autoquery
           echo "App launched with --autoquery"
 
       - name: Quick startup check (60s fast-fail)
@@ -186,15 +181,16 @@ jobs:
             find "$CRASH_DIR" -name "ZeldaGuide*.crash" -exec head -60 {} \;
             exit 1
           fi
-          if grep -q "Guide unavailable\|LLM unavailable\|EmbeddingError\|fatal error\|SIGABRT" \
-              "$RUNNER_TEMP/app_stdout.log" 2>/dev/null; then
-            echo "FAST-FAIL: startup error detected in app stdout:"
-            cat "$RUNNER_TEMP/app_stdout.log"
+          if grep -q "Guide unavailable\|LLM unavailable\|LLM load failed\|Tokenizer load failed" \
+              "$RUNNER_TEMP/simulator.log" 2>/dev/null; then
+            echo "FAST-FAIL: startup error detected in simulator log:"
+            grep "Guide unavailable\|LLM unavailable\|LLM load failed\|Tokenizer load failed" \
+              "$RUNNER_TEMP/simulator.log"
             exit 1
           fi
-          echo "60s check passed — no crash or startup error. Proceeding to 45-min model load wait."
-          echo "App stdout so far:"
-          cat "$RUNNER_TEMP/app_stdout.log" 2>/dev/null || echo "(empty)"
+          echo "60s check passed — no crash or startup error. Proceeding to model load wait."
+          echo "Simulator log so far (LLMService lines):"
+          grep "LLMService\|CI-AUTOQUERY" "$RUNNER_TEMP/simulator.log" 2>/dev/null || echo "(none yet — model loading)"
 
       - name: Wait for RAG pipeline to complete (up to 45 min)
         run: |
@@ -214,14 +210,14 @@ jobs:
               echo "ZeldaGuide crash report found."
               break
             fi
-            # Stop as soon as we have a CI-AUTOQUERY result (app stdout).
-            if grep -q "CI-AUTOQUERY" "$RUNNER_TEMP/app_stdout.log" 2>/dev/null; then
+            # Stop as soon as we have a CI-AUTOQUERY result (via Logger / log stream).
+            if grep -q "CI-AUTOQUERY" "$RUNNER_TEMP/simulator.log" 2>/dev/null; then
               echo "Found [CI-AUTOQUERY] marker — stopping early."
               break
             fi
-            # Also surface any LLM/embedding errors from app stdout.
-            if grep -q "EmbeddingError\|LLMError\|Guide unavailable\|LLM unavailable" \
-                "$RUNNER_TEMP/app_stdout.log" 2>/dev/null; then
+            # Also surface any LLM/embedding errors.
+            if grep -q "LLM load failed\|Tokenizer load failed\|Guide unavailable\|LLM unavailable" \
+                "$RUNNER_TEMP/simulator.log" 2>/dev/null; then
               echo "Found error marker — stopping early."
               break
             fi
@@ -234,9 +230,7 @@ jobs:
       - name: Print simulator console log
         if: always()
         run: |
-          echo "=== App stdout/stderr (print() output) ==="
-          cat "$RUNNER_TEMP/app_stdout.log" || echo "(app stdout log not found)"
-          echo "=== Simulator system log (os_log output) ==="
+          echo "=== Simulator log (os_log — includes Logger output from app) ==="
           cat "$RUNNER_TEMP/simulator.log" || echo "(simulator log not found)"
 
       - name: Check for crash reports
@@ -256,7 +250,7 @@ jobs:
 
       - name: Assert RAG pipeline passed
         run: |
-          LOG="$RUNNER_TEMP/app_stdout.log"
+          LOG="$RUNNER_TEMP/simulator.log"
           if grep -q "\[CI-AUTOQUERY\] PASS" "$LOG" 2>/dev/null; then
             echo "RAG pipeline: PASS"
             grep "\[CI-AUTOQUERY\]" "$LOG"
@@ -272,7 +266,7 @@ jobs:
       - name: Write job summary
         if: always()
         run: |
-          LOG="$RUNNER_TEMP/app_stdout.log"
+          LOG="$RUNNER_TEMP/simulator.log"
           if grep -q "\[CI-AUTOQUERY\] PASS" "$LOG" 2>/dev/null; then
             RESULT="PASS ✓"
           elif grep -q "\[CI-AUTOQUERY\] FAIL" "$LOG" 2>/dev/null; then

--- a/ios/ZeldaGuide/Models/ChatViewModel.swift
+++ b/ios/ZeldaGuide/Models/ChatViewModel.swift
@@ -3,6 +3,9 @@
 // Owns the RAGEngine, manages the message list, and handles streaming cancellation.
 
 import Foundation
+import os
+
+private let ciLog = Logger(subsystem: "com.tlo300.ZeldaGuide", category: "CI")
 
 @MainActor
 final class ChatViewModel: ObservableObject {
@@ -31,7 +34,7 @@ final class ChatViewModel: ObservableObject {
                     }
                 } catch {
                     if ProcessInfo.processInfo.arguments.contains("--autoquery") {
-                        print("[CI-AUTOQUERY] FAIL: engine.prepare() threw — \(error.localizedDescription)")
+                        ciLog.notice("[CI-AUTOQUERY] FAIL: engine.prepare() threw — \(error.localizedDescription, privacy: .public)")
                     }
                     messages.append(ChatMessage(
                         role: .assistant,
@@ -116,18 +119,18 @@ final class ChatViewModel: ObservableObject {
     /// Invoked automatically when the app is launched with `--autoquery`.
     private func runCIAutoQuery(engine: RAGEngine) async {
         let question = "What is a Korok Seed?"
-        print("[CI-AUTOQUERY] Engine ready — submitting test query: \(question)")
+        ciLog.notice("[CI-AUTOQUERY] Engine ready — submitting test query: \(question, privacy: .public)")
         let stream = await engine.answer(question: question)
         var answer = ""
         for await token in stream {
             answer += token
         }
         if answer.isEmpty {
-            print("[CI-AUTOQUERY] FAIL: got empty answer")
+            ciLog.notice("[CI-AUTOQUERY] FAIL: got empty answer")
         } else if answer.hasPrefix("[Error:") {
-            print("[CI-AUTOQUERY] FAIL: \(answer)")
+            ciLog.notice("[CI-AUTOQUERY] FAIL: \(answer, privacy: .public)")
         } else {
-            print("[CI-AUTOQUERY] PASS: \(answer.prefix(200))")
+            ciLog.notice("[CI-AUTOQUERY] PASS: \(answer.prefix(200), privacy: .public)")
         }
     }
 }

--- a/ios/ZeldaGuide/Services/LLMService.swift
+++ b/ios/ZeldaGuide/Services/LLMService.swift
@@ -5,6 +5,9 @@
 import CoreML
 import Foundation
 import UIKit
+import os
+
+private let llmLog = Logger(subsystem: "com.tlo300.ZeldaGuide", category: "LLMService")
 
 // MARK: - Errors
 
@@ -122,11 +125,15 @@ actor LLMService {
             // CPU-only execution; on device it uses CPU+GPU.
             config.computeUnits = .cpuAndGPU
             let compiledURL = try await compileAndCache(modelURL)
+            llmLog.notice("MLModel.load starting — this may take 30+ min in the simulator")
             let model = try await MLModel.load(contentsOf: compiledURL, configuration: config)
+            llmLog.notice("MLModel.load complete")
             predictor = CoreMLPredictor(model: model)
         } catch let e as LLMError {
+            llmLog.error("LLM load failed: \(e.localizedDescription, privacy: .public)")
             throw e
         } catch {
+            llmLog.error("LLM load failed: \(error.localizedDescription, privacy: .public)")
             throw LLMError.loadFailed(error)
         }
 
@@ -134,8 +141,11 @@ actor LLMService {
             throw LLMError.modelNotFound("tokenizer.json")
         }
         do {
+            llmLog.notice("Loading tokenizer")
             tokenizer = try BPETokenizer(url: tokURL)
+            llmLog.notice("Tokenizer loaded")
         } catch {
+            llmLog.error("Tokenizer load failed: \(error.localizedDescription, privacy: .public)")
             throw LLMError.loadFailed(error)
         }
         registerMemoryWarningHandler()


### PR DESCRIPTION
Swift `print()` does not write to fd1 in the iOS simulator — `simctl launch --stdout=` captures nothing (confirmed: `app_stdout.log` was completely empty after the full 45-min run).

`Logger` (os_log) is the correct mechanism; it IS captured by `log stream --predicate`.

**Changes:**
- `ChatViewModel`: `print("[CI-AUTOQUERY]...")` → `Logger.notice()`
- `LLMService`: add `Logger.notice()` before/after `MLModel.load()` so we can see in the simulator log whether the model is loading or silently hanging
- `debug-simulator.yml`: remove `--stdout`/`--stderr` flags, revert all grep targets back to `simulator.log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)