### PR TITLE
fix: wait for CI-AUTOQUERY PASS/FAIL not just Engine ready

### DIFF
--- a/.github/workflows/debug-simulator.yml
+++ b/.github/workflows/debug-simulator.yml
@@ -210,9 +210,9 @@ jobs:
               echo "ZeldaGuide crash report found."
               break
             fi
-            # Stop as soon as we have a CI-AUTOQUERY result (via Logger / log stream).
-            if grep -q "CI-AUTOQUERY" "$RUNNER_TEMP/simulator.log" 2>/dev/null; then
-              echo "Found [CI-AUTOQUERY] marker — stopping early."
+            # Stop as soon as we have a PASS or FAIL result (not just "Engine ready").
+            if grep -qE "\[CI-AUTOQUERY\] (PASS|FAIL)" "$RUNNER_TEMP/simulator.log" 2>/dev/null; then
+              echo "Found [CI-AUTOQUERY] PASS or FAIL — stopping early."
               break
             fi
             # Also surface any LLM/embedding errors.


### PR DESCRIPTION
Wait loop was matching any `CI-AUTOQUERY` line including `Engine ready — submitting test query`, exiting before generation completed, then assert failed with "no marker found".

Fix: check for `\[CI-AUTOQUERY\] (PASS|FAIL)` specifically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)