### PR TITLE
Fix: add generation stop-reason logging + raise RAG chunk limit

### DIFF
--- a/ios/ZeldaGuide/Services/LLMService.swift
+++ b/ios/ZeldaGuide/Services/LLMService.swift
@@ -204,24 +204,39 @@ actor LLMService {
         var inputTokens = tokenizer.encode(ModelConfig.chatPrompt(userQuery: prompt))
         let eosID  = tokenizer.eosTokenID
         let maxNew = ModelConfig.maxOutputTokens
+        var tokenCount = 0
+
+        llmLog.notice("Generation starting — prompt tokens: \(inputTokens.count, privacy: .public), maxNew: \(maxNew, privacy: .public)")
 
         for _ in 0..<maxNew {
             // Stop before exceeding the model's RangeDim upper bound — passing more tokens
             // than the compiled max_context raises an uncatchable NSException.
-            if inputTokens.count >= ModelConfig.modelMaxSequenceLength { break }
-
-            // Yield the actor so that a concurrent generate() call can cancel this task.
-            await Task.yield()
-            if Task.isCancelled { break }
-
-            if isMemoryPressured {
-                print("[LLMService] Generation paused — memory warning received")
+            if inputTokens.count >= ModelConfig.modelMaxSequenceLength {
+                llmLog.notice("Generation stopped — sequence length limit (\(ModelConfig.modelMaxSequenceLength, privacy: .public)) reached after \(tokenCount, privacy: .public) tokens")
                 break
             }
 
-            guard let logits = try? await predictor.predict(inputIDs: inputTokens) else { break }
+            // Yield the actor so that a concurrent generate() call can cancel this task.
+            await Task.yield()
+            if Task.isCancelled {
+                llmLog.notice("Generation cancelled after \(tokenCount, privacy: .public) tokens")
+                break
+            }
 
-            if Task.isCancelled { break }
+            if isMemoryPressured {
+                llmLog.notice("Generation stopped — memory pressure after \(tokenCount, privacy: .public) tokens")
+                break
+            }
+
+            guard let logits = try? await predictor.predict(inputIDs: inputTokens) else {
+                llmLog.error("Generation stopped — predictor failed after \(tokenCount, privacy: .public) tokens")
+                break
+            }
+
+            if Task.isCancelled {
+                llmLog.notice("Generation cancelled after \(tokenCount, privacy: .public) tokens")
+                break
+            }
 
             // Greedy decoding: pick the token with the highest logit.
             var maxLogit = Float(-Float.infinity)
@@ -231,14 +246,19 @@ actor LLMService {
             }
 
             // Stop on <|im_end|> (151645) or <|endoftext|> (151643).
-            if nextToken == eosID || nextToken == 151643 { break }
+            if nextToken == eosID || nextToken == 151643 {
+                llmLog.notice("Generation stopped — EOS token \(nextToken, privacy: .public) after \(tokenCount, privacy: .public) tokens")
+                break
+            }
             inputTokens.append(nextToken)
+            tokenCount += 1
 
             let text = tokenizer.decode(tokenID: nextToken)
             if !text.isEmpty {
                 continuation.yield(text)
             }
         }
+        llmLog.notice("Generation complete — \(tokenCount, privacy: .public) tokens yielded")
     }
 
     private func registerMemoryWarningHandler() {

--- a/ios/ZeldaGuide/Services/RAGEngine.swift
+++ b/ios/ZeldaGuide/Services/RAGEngine.swift
@@ -262,11 +262,10 @@ actor RAGEngine {
         if chunks.isEmpty {
             contextBlock = "(No relevant information found in the knowledge base.)"
         } else {
-            // Limit each chunk to 500 characters (~130 BPE tokens) so the full assembled
-            // prompt stays within the 512-token model limit. Remove this cap after
-            // re-running convert-model with max_context = 2048 (issue #83).
+            // Limit each chunk to 1500 characters (~400 BPE tokens) to stay comfortably
+            // within the 2048-context model limit with 5 chunks + system prompt overhead.
             contextBlock = chunks.enumerated().map { index, chunk in
-                let text = String(chunk.chunkText.prefix(500))
+                let text = String(chunk.chunkText.prefix(1500))
                 return "[\(index + 1)] (source: \(chunk.source) | \(chunk.pageTitle))\n\(text)"
             }.joined(separator: "\n\n")
         }


### PR DESCRIPTION
## Summary
- Adds `os_log` diagnostics at every exit point in `LLMService.runGeneration` so we can see whether the 1-token truncation is caused by memory pressure, early EOS, cancellation, or sequence length
- Raises per-chunk cap in `RAGEngine` from 500 → 1500 chars (the 2048-context model is deployed, the 500-char limit was a temporary workaround from before #83)

## Test plan
- [ ] CI build-ipa succeeds
- [ ] Sideload and ask a question — check device logs for the `Generation stopped —` line
- [ ] Answers are longer than 1 token

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)