### PR TITLE
fix: slice logits to last token to fix OOM crash + add im_start stop token

### DIFF
--- a/ios/ZeldaGuide/Services/LLMService.swift
+++ b/ios/ZeldaGuide/Services/LLMService.swift
@@ -245,8 +245,10 @@ actor LLMService {
                 if v > maxLogit { maxLogit = v; nextToken = Int32(i) }
             }
 
-            // Stop on <|im_end|> (151645) or <|endoftext|> (151643).
-            if nextToken == eosID || nextToken == 151643 {
+            // Stop on <|im_end|> (151645), <|endoftext|> (151643), or <|im_start|> (151644).
+            // Including im_start prevents the model from generating a fake new user/system turn
+            // if it fails to emit im_end first.
+            if nextToken == eosID || nextToken == 151643 || nextToken == 151644 {
                 llmLog.notice("Generation stopped — EOS token \(nextToken, privacy: .public) after \(tokenCount, privacy: .public) tokens")
                 break
             }

--- a/model/convert_llm.py
+++ b/model/convert_llm.py
@@ -210,7 +210,10 @@ def convert(output_dir: str, variant: str, hf_token: str) -> None:
             self.m = m
 
         def forward(self, input_ids, attention_mask):
-            return self.m(input_ids=input_ids, attention_mask=attention_mask).logits
+            # Slice to last token only: [1, seq, vocab] → [1, 1, vocab].
+            # The full-sequence logits tensor grows to >1 GB at 2048-context lengths and
+            # causes OOM kills on device. Returning only the last token reduces it to ~600 KB.
+            return self.m(input_ids=input_ids, attention_mask=attention_mask).logits[:, -1:, :]
 
     wrapped = _LogitsWrapper(model)
     wrapped.eval()


### PR DESCRIPTION
Closes #103

## Summary

- **`model/convert_llm.py`**: `_LogitsWrapper.forward()` now returns `logits[:, -1:, :]` — output shape changes from `[1, seqLen, vocab]` to `[1, 1, vocab]`. This cuts the output tensor from ~1 GB (at seqLen=1913) down to ~600 KB, eliminating the OOM kill on device during long generations.
- **`ios/ZeldaGuide/Services/LLMService.swift`**: added token 151644 (`<|im_start|>`) to the stop-token set alongside 151643 (`<|endoftext|>`) and 151645 (`<|im_end|>`).

The Swift `CoreMLPredictor` already handles both `[1, seqLen, vocab]` and `[1, 1, vocab]` output shapes correctly (reads `mla.shape[1]` dynamically), so no Swift change is needed there. The smoke test in `convert_llm.py` uses `output["logits"][0, -1, :]` which works for both shapes.

## Root cause

Raising `max_context` from 512 → 2048 in #89 made the logits tensor 4× larger. At 1401-token prompts + 512 generated tokens, the tensor hit ~1.16 GB → OOM kill. This showed up as the "korok seed question crashes" symptom.

## After this PR

Re-run the convert-model CI job to produce a new `.mlmodelc` with the sliced output, then re-run debug-simulator.

## Test plan
- [ ] convert-model CI job completes successfully with new sliced output
- [ ] Smoke test in convert_llm.py passes (logits shape is `[1, 1, vocab]`)
- [ ] debug-simulator prints `[CI-AUTOQUERY] PASS` for "What is a Korok Seed?"
- [ ] On-device: korok seed question no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)