### PR TITLE
fix: HyruleSage context echo + SQLiteVec error 1 on follow-up

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,13 +190,13 @@ Create docs/decisions/NNN-short-title.md with:
 
 ## Current state
 Active milestone : 4 - Polish and distribution
-Last completed  : ZeldaWalkthrough app + content pipeline (2026-03-28)
-In progress     : nothing
+Last completed  : #116 fix HyruleSage maxContextTokens overflow (merged 2026-03-28)
+In progress     : #117/#118 fix HyruleSage context echo + SQLiteVec error 1 (PR open, awaiting CI + device test)
 Blocked         : nothing
-Last session    : 2026-03-28 — Built ZeldaWalkthrough (4th app): pure SwiftUI chapter-based TotK guide; 75 sections populated from chunks.jsonl via keyword scoring (pipeline/generate_walkthrough_content.py); build-ipa-walkthrough.yml CI (~2 min, no ML); IPA released successfully
+Last session    : 2026-03-28 — Device-tested HyruleSage R4; found [N] citation echo + SQLiteVec error 1 on follow-up; fixed in PR #118
 
 Notes:
-- HyruleSage: IPA from run 23687306531 is the one to test — fixes blank/empty responses when asking questions
+- HyruleSage: R4 device-tested 2026-03-28 — blank responses fixed (#116), but context echo ([N] format) + SQLiteVec error 1 on follow-up found; fixed in #118 (PR open)
 - HyruleSage blank response root cause: maxContextTokens=1500 caused ~1500-token prefill, overflowing 512-slot KV cache; same bug as ZeldaGuide #111, fixed in #116 (maxContextTokens=380)
 - HyruleSage model artifacts: convert-model-llama run 23683351896 (LlamaModel-1B.mlpackage + tokenizer-llama.json)
 - ZeldaGuide (Qwen): R36 is the current IPA — has context-overflow fix (#111) + RAG echo fix (chunk format)
@@ -253,6 +253,7 @@ Notes:
 | #111  | Fix RAG prompt overflow (no answer generated) | 4 | merged |
 | #115  | Add HyruleSage app — Llama 3.2 powered Zelda TotK guide | 4 | merged |
 | #116  | Fix HyruleSage blank responses (maxContextTokens overflow) | 4 | merged |
+| #117  | Fix HyruleSage context echo + SQLiteVec error 1 on follow-up | 4 | PR #118 |
 | #69   | Add in-app log viewer for on-device debugging | 4 | backlog |
 
 ---

--- a/ios/HyruleSage/Services/RAGEngine.swift
+++ b/ios/HyruleSage/Services/RAGEngine.swift
@@ -178,8 +178,8 @@ actor RAGEngine {
             return
         }
 
-        guard !queryEmbedding.contains(where: { $0.isNaN }) else {
-            continuation.yield("[Error: Query embedding contains NaN — cannot perform vector search]")
+        guard !queryEmbedding.contains(where: { $0.isNaN || $0.isInfinite }) else {
+            continuation.yield("[Error: Query embedding contains NaN/Inf — cannot perform vector search]")
             return
         }
 
@@ -209,9 +209,9 @@ actor RAGEngine {
             contextBlock = "(No relevant information found in the knowledge base.)"
         } else {
             let charsPerChunk = (ModelConfig.maxContextTokens * 4) / max(chunks.count, 1)
-            contextBlock = chunks.enumerated().map { index, chunk in
+            contextBlock = chunks.enumerated().map { _, chunk in
                 let text = String(chunk.chunkText.prefix(charsPerChunk))
-                return "[\(index + 1)] (source: \(chunk.source) | \(chunk.pageTitle))\n\(text)"
+                return "<<\(chunk.source) | \(chunk.pageTitle)>>\n\(text)"
             }.joined(separator: "\n\n")
         }
         return "Context:\n\(contextBlock)\n\nQuestion: \(question)"

--- a/ios/HyruleSage/Services/VectorSearchService.swift
+++ b/ios/HyruleSage/Services/VectorSearchService.swift
@@ -55,7 +55,13 @@ actor VectorSearchService {
     /// when vector search returns no results OR when the best similarity score is below
     /// `ModelConfig.minVectorSimilarity`.
     func search(queryText: String, queryEmbedding: [Float], topK: Int) async throws -> [KnowledgeChunk] {
-        let results = try await vectorSearch(query: queryEmbedding, topK: topK)
+        let results: [KnowledgeChunk]
+        do {
+            results = try await vectorSearch(query: queryEmbedding, topK: topK)
+        } catch {
+            vsLog.error("Vector search error: \(error.localizedDescription, privacy: .public) — falling back to FTS5")
+            return try await ftsSearch(queryText: queryText, topK: topK)
+        }
         let bestSimilarity = results.map(\.similarityScore).max() ?? 0
         vsLog.notice("Vector search: \(results.count, privacy: .public) results, best similarity \(bestSimilarity, privacy: .public)")
         for (i, chunk) in results.enumerated() {


### PR DESCRIPTION
Closes #117

## What was wrong (observed in R4 on device)

**Bug 1 — context echo:** Response to "How do I get the hylian shield" started with `zelda_wiki | Hylian Shield)` — the model was echoing the tail of the chunk citation `[1] (source: zelda_wiki | Hylian Shield)`. HyruleSage still had the old `[N] (source: ...)` format that ZeldaGuide fixed in R36.

**Bug 2 — SQLiteVec error 1 on follow-up:** "But where do I find it?" returned `[Error: Vector search failed — SQLiteVec.SQLiteVecError error 1]`. The `search(queryText:queryEmbedding:topK:)` method let any vec0 error propagate straight out with no fallback.

## Fixes

- `RAGEngine.swift`: change chunk header from `[N] (source: src | title)` → `<<src | title>>` (matches ZeldaGuide R36 format)
- `RAGEngine.swift`: add `isInfinite` check alongside `isNaN` for query embeddings
- `VectorSearchService.swift`: wrap `vectorSearch` in try/catch — any SQLiteVec error falls back to FTS5 instead of propagating

## Test plan
- [ ] Build IPA via build-ipa-hyrule-sage workflow
- [ ] Ask "How do I get the hylian shield" — response should answer the question, not echo `zelda_wiki | Hylian Shield)`
- [ ] Ask "But where do I find it?" as follow-up — should return an answer or FTS5 result, not `[Error: Vector search failed]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)